### PR TITLE
Reset page query param after successfully revoking a code from search results

### DIFF
--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TransitionReplace } from '@edx/paragon';
 
-import { isValidEmail } from '../../utils';
+import { isValidEmail, updateUrl } from '../../utils';
 
 import StatusAlert from '../StatusAlert';
 import CodeSearchResultsHeading from './CodeSearchResultsHeading';
@@ -48,6 +48,7 @@ class CodeSearchResults extends React.Component {
   };
 
   handleRevokeOnSuccess = () => {
+    updateUrl({ page: undefined });
     this.setState({
       isCodeRevokeSuccessful: true,
       shouldRefreshTable: true,


### PR DESCRIPTION
If you revoke a code when it is the only row in the table on page 2, the frontend will attempt to reload the table data for that same page. However, since this the revoked code was the only result for that page, the API then returns a 404. To account for this, we remove the `page` query parameter after a successful revoke, such that the table fetches page 1 of the search results.