### PR TITLE
Remove reporting config for enterprises that do not have it activated.

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -155,6 +155,7 @@ module.exports = Merge.smart(commonConfig, {
       NEW_RELIC_LICENSE_KEY: null,
       FEATURE_FLAGS: {
         CODE_MANAGEMENT: true,
+        REPORTING_CONFIGURATIONS: true,
       },
     }),
     new HtmlWebpackNewRelicPlugin({

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -40,7 +40,7 @@ class Sidebar extends React.Component {
   }
 
   getMenuItems() {
-    const { baseUrl, enableCodeManagementScreen } = this.props;
+    const { baseUrl, enableCodeManagementScreen, enableReportingConfigScreen } = this.props;
 
     return [
       {
@@ -58,7 +58,7 @@ class Sidebar extends React.Component {
         title: 'Reporting Configurations',
         to: `${baseUrl}/admin/reporting`,
         iconClassName: 'fa-file',
-        hidden: !features.REPORTING_CONFIGURATIONS,
+        hidden: !features.REPORTING_CONFIGURATIONS || !enableReportingConfigScreen,
       },
     ];
   }
@@ -142,6 +142,7 @@ Sidebar.propTypes = {
   isExpanded: PropTypes.bool.isRequired,
   isExpandedByToggle: PropTypes.bool.isRequired,
   enableCodeManagementScreen: PropTypes.bool.isRequired,
+  enableReportingConfigScreen: PropTypes.bool.isRequired,
   onWidthChange: PropTypes.func,
   isMobile: PropTypes.bool,
 };

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -12,6 +12,7 @@ const mapStateToProps = state => ({
   isExpanded: state.sidebar.isExpanded,
   isExpandedByToggle: state.sidebar.isExpandedByToggle,
   enableCodeManagementScreen: state.portalConfiguration.enableCodeManagementScreen,
+  enableReportingConfigScreen: state.portalConfiguration.enableReportingConfigScreen,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/data/reducers/portalConfiguration.js
+++ b/src/data/reducers/portalConfiguration.js
@@ -35,6 +35,7 @@ const portalConfiguration = (state = initialState, action) => {
           ? action.payload.data.branding_configuration.logo
           : null,
         enableCodeManagementScreen: action.payload.data.enable_portal_code_management_screen,
+        enableReportingConfigScreen: action.payload.data.enable_portal_reporting_config_screen,
       };
     case FETCH_PORTAL_CONFIGURATION_FAILURE:
       return {


### PR DESCRIPTION
Turns on the feature flag for Reporting configurations in stage + production. If an EnterpriseCustomer does not have this feature enabled, they will not see the page in the sidebar.