### PR TITLE
Added a notes field so that the requestor can write notes for the codes.

### DIFF
--- a/src/components/RequestCodesPage/RequestCodesForm.jsx
+++ b/src/components/RequestCodesPage/RequestCodesForm.jsx
@@ -7,7 +7,7 @@ import { Button, Icon } from '@edx/paragon';
 import RenderField from '../RenderField';
 import StatusAlert from '../StatusAlert';
 
-import { isRequired, isValidEmail, isValidNumber } from '../../utils';
+import { isRequired, isValidEmail, isValidNumber, maxLength512 } from '../../utils';
 
 class RequestCodesForm extends React.Component {
   constructor(props) {
@@ -97,6 +97,13 @@ class RequestCodesForm extends React.Component {
                 component={RenderField}
                 label="Number of Codes"
                 validate={[isValidNumber]}
+              />
+              <Field
+                name="notes"
+                type="text"
+                component={RenderField}
+                label="Notes"
+                validate={[maxLength512]}
               />
               <Button
                 type="submit"

--- a/src/components/RequestCodesPage/index.jsx
+++ b/src/components/RequestCodesPage/index.jsx
@@ -45,7 +45,9 @@ class RequestCodesPage extends React.Component {
                         throw new SubmissionError({ _error: error });
                       })
                   )}
-                  initialValues={{ emailAddress, enterpriseName, numberOfCodes: '' }}
+                  initialValues={{
+                    emailAddress, enterpriseName, numberOfCodes: '', notes: '',
+                  }}
                   match={match}
                 />
               ) : <LoadingMessage className="request-codes" />}

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -47,6 +47,7 @@ class LmsApiService {
       email: options.emailAddress,
       enterprise_name: options.enterpriseName,
       number_of_codes: options.numberOfCodes,
+      notes: options.notes,
     };
     const requestCodesUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/request_codes`;
     return apiClient.post(requestCodesUrl, postParams, 'json');

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,8 @@ const isTriggerKey = ({ triggerKeys, action, key }) => (
 const isRequired = (value = '') => (isEmpty(value) ? 'This field is required.' : undefined);
 const isValidEmail = (value = '') => (!isEmail(value) ? 'Must be a valid email address.' : undefined);
 const isValidNumber = (value = '') => (!isEmpty(value) && !isNumeric(value, { no_symbols: true }) ? 'Must be a valid number.' : undefined);
+const maxLength = max => value => (value && value.length > max ? 'Must be 512 characters or less' : undefined);
+const maxLength512 = maxLength(512);
 
 
 /** camelCase <--> snake_case functions
@@ -141,4 +143,5 @@ export {
   camelCaseObject,
   snakeCaseObject,
   snakeCaseFormData,
+  maxLength512,
 };


### PR DESCRIPTION
This ticket is related to provide a box so that the requestor can write notes & specifications for the codes they're ordering, to streamline the communication. 

**Page URL** = ` /{enterprise-slug}/admin/coupons/request`

**Pre PR: **
When the user will visit this page there will be three fields.
1.Email Address
2.Company
3.Number of codes
**Post PR: **
When the user will visit this page there will be an extra field named notes.
1.Email Address
2.Company
3.Number of codes
4.Notes
Max Length For this field is assumed 512 characters.
**Dependency:**
Backend PR for this ticket is
https://github.com/edx/edx-enterprise/pull/594

[ENT-2213](https://openedx.atlassian.net/browse/ENT-2213)
