### PR TITLE
Add old progress data type support for reporting configurations

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -171,7 +171,7 @@ class ReportingConfigForm extends React.Component {
           <div className="col col-6">
             <ValidationFormGroup
               for="dataType"
-              helpText="The type of data this report should contain"
+              helpText="The type of data this report should contain. If this is an old report, you will not be able to change this field, and should create a new report"
             >
               <label htmlFor="dataType">Data Type</label>
               <Input
@@ -179,9 +179,11 @@ class ReportingConfigForm extends React.Component {
                 id="dataType"
                 name="dataType"
                 defaultValue={config ? config.dataType : 'progress_v2'}
+                disabled={config && config.dataType === 'progress'}
                 options={[
                   { value: 'progress_v2', label: 'progress' },
                   { value: 'catalog', label: 'catalog' },
+                  { value: 'progress', label: 'progress', hidden: true },
                 ]}
               />
             </ValidationFormGroup>

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -21,8 +21,8 @@ const config = {
   uuid: 'test-config-uuid',
 };
 
-const createConfig = () => {};
-const updateConfig = () => {};
+const createConfig = () => { };
+const updateConfig = () => { };
 
 describe('<ReportingConfigForm />', () => {
   it('renders the proper fields when changing the delivery method', () => {
@@ -104,5 +104,22 @@ describe('<ReportingConfigForm />', () => {
       />
     ));
     expect(wrapper.find('select#dataType').prop('disabled')).toBeTruthy();
+  });
+  it('Does not disable data type when using new progress/catalog', () => {
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={config}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+      />
+    ));
+    expect(wrapper.find('select#dataType').prop('disabled')).toBeFalsy();
+    wrapper.find('select#dataType').simulate('change', {
+      target: {
+        name: 'dataType',
+        value: 'catalog',
+      },
+    });
+    expect(wrapper.find('select#dataType').prop('disabled')).toBeFalsy();
   });
 });

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -90,4 +90,19 @@ describe('<ReportingConfigForm />', () => {
     expect(wrapper.find('input#sftpFilePath').hasClass('is-invalid')).toBeTruthy();
     expect(wrapper.find('input#encryptedSftpPassword').hasClass('is-invalid')).toBeTruthy();
   });
+  it('Does not let you select a new value for data type if it uses the old progress_v1', () => {
+    const configWithOldDataType = {
+      ...config,
+      dataType: 'progress',
+    };
+
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={configWithOldDataType}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+      />
+    ));
+    expect(wrapper.find('select#dataType').prop('disabled')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Some Enterprise reporting configs have an old reporting data type that we don't want to create more of. We still need to maintain these reports, so they will still show up in the list of configs. You will not be able to change the type of the report, so if a different type of report is needed, you must create a new one.