### PR TITLE
ENT-2640 Add new Subscription Management tab to admin dashboard

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -116,6 +116,7 @@ module.exports = Merge.smart(commonConfig, {
       FEATURE_FLAGS: {
         CODE_MANAGEMENT: true,
         REPORTING_CONFIGURATIONS: true,
+        SUBSCRIPTION_MANAGEMENT: true,
       },
     }),
   ],

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -156,6 +156,7 @@ module.exports = Merge.smart(commonConfig, {
       FEATURE_FLAGS: {
         CODE_MANAGEMENT: true,
         REPORTING_CONFIGURATIONS: true,
+        SUBSCRIPTION_MANAGEMENT: false,
       },
     }),
     new HtmlWebpackNewRelicPlugin({

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -78,7 +78,12 @@ class EnterpriseApp extends React.Component {
   }
 
   render() {
-    const { error, match, enableCodeManagementScreen } = this.props;
+    const {
+      error,
+      match,
+      enableCodeManagementScreen,
+      enableSubscriptionManagementScreen,
+    } = this.props;
     const { sidebarWidth } = this.state;
     const baseUrl = match.url;
     const defaultContentPadding = 10; // 10px for appropriate padding
@@ -151,6 +156,16 @@ class EnterpriseApp extends React.Component {
                       )}
                     />
                   }
+                  {features.SUBSCRIPTION_MANAGEMENT && enableSubscriptionManagementScreen &&
+                    <Route
+                      key="subscription-management"
+                      exact
+                      path={`${baseUrl}/admin/subscriptions`}
+                      render={routeProps =>
+                        <CodeManagementPage {...routeProps} />
+                      }
+                    />
+                  }
                   <Route exact path={`${baseUrl}/support`} component={SupportPage} />
                   <Route path="" component={NotFoundPage} />
                 </Switch>
@@ -178,6 +193,7 @@ EnterpriseApp.propTypes = {
   location: PropTypes.shape({}).isRequired,
   toggleSidebarToggle: PropTypes.func.isRequired,
   enableCodeManagementScreen: PropTypes.bool.isRequired,
+  enableSubscriptionManagementScreen: PropTypes.bool.isRequired,
   error: PropTypes.instanceOf(Error),
 };
 

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -40,7 +40,12 @@ class Sidebar extends React.Component {
   }
 
   getMenuItems() {
-    const { baseUrl, enableCodeManagementScreen, enableReportingConfigScreen } = this.props;
+    const {
+      baseUrl,
+      enableCodeManagementScreen,
+      enableReportingConfigScreen,
+      enableSubscriptionManagementScreen,
+    } = this.props;
 
     return [
       {
@@ -59,6 +64,12 @@ class Sidebar extends React.Component {
         to: `${baseUrl}/admin/reporting`,
         iconClassName: 'fa-file',
         hidden: !features.REPORTING_CONFIGURATIONS || !enableReportingConfigScreen,
+      },
+      {
+        title: 'Subscription Management',
+        to: `${baseUrl}/admin/subscriptions`,
+        iconClassName: 'fa-credit-card',
+        hidden: !features.SUBSCRIPTION_MANAGEMENT || !enableSubscriptionManagementScreen,
       },
     ];
   }
@@ -143,6 +154,7 @@ Sidebar.propTypes = {
   isExpandedByToggle: PropTypes.bool.isRequired,
   enableCodeManagementScreen: PropTypes.bool.isRequired,
   enableReportingConfigScreen: PropTypes.bool.isRequired,
+  enableSubscriptionManagementScreen: PropTypes.bool.isRequired,
   onWidthChange: PropTypes.func,
   isMobile: PropTypes.bool,
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,6 +24,7 @@ const configuration = {
 const features = {
   CODE_MANAGEMENT: process.env.FEATURE_FLAGS.CODE_MANAGEMENT || hasFeatureFlagEnabled('CODE_MANAGEMENT'),
   REPORTING_CONFIGURATIONS: process.env.FEATURE_FLAGS.REPORTING_CONFIGURATIONS,
+  SUBSCRIPTION_MANAGEMENT: process.env.FEATURE_FLAGS.SUBSCRIPTION_MANAGEMENT || hasFeatureFlagEnabled('SUBSCRIPTION_MANAGEMENT'),
 };
 
 export { configuration, features };

--- a/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
@@ -22,6 +22,7 @@ const initialState = {
   portalConfiguration: {
     enterpriseId: 'test-enterprise-id',
     enableCodeManagementScreen: true,
+    enableSubscriptionManagementScreen: true,
   },
   csv: {},
   table: {

--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state) => {
     enterprises: enterpriseListState.data,
     error: state.portalConfiguration.error,
     enableCodeManagementScreen: state.portalConfiguration.enableCodeManagementScreen,
+    enableSubscriptionManagementScreen: state.portalConfiguration.enableSubscriptionManagementScreen, // eslint-disable-line max-len
     enterpriseId: state.portalConfiguration.enterpriseId,
   };
 };

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -26,6 +26,7 @@ const initialState = {
   },
   portalConfiguration: {
     enableCodeManagementScreen: true,
+    enableSubscriptionManagementScreen: true,
   },
 };
 

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -13,6 +13,7 @@ const mapStateToProps = state => ({
   isExpandedByToggle: state.sidebar.isExpandedByToggle,
   enableCodeManagementScreen: state.portalConfiguration.enableCodeManagementScreen,
   enableReportingConfigScreen: state.portalConfiguration.enableReportingConfigScreen,
+  enableSubscriptionManagementScreen: state.portalConfiguration.enableSubscriptionManagementScreen,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/data/reducers/portalConfiguration.js
+++ b/src/data/reducers/portalConfiguration.js
@@ -13,6 +13,8 @@ const initialState = {
   enterpriseSlug: null,
   enterpriseLogo: null,
   enableCodeManagementScreen: false,
+  enableReportingConfigScreen: false,
+  enableSubscriptionManagementScreen: false,
 };
 
 const portalConfiguration = (state = initialState, action) => {
@@ -36,6 +38,7 @@ const portalConfiguration = (state = initialState, action) => {
           : null,
         enableCodeManagementScreen: action.payload.data.enable_portal_code_management_screen,
         enableReportingConfigScreen: action.payload.data.enable_portal_reporting_config_screen,
+        enableSubscriptionManagementScreen: action.payload.data.enable_portal_subscription_management_screen, // eslint-disable-line max-len
       };
     case FETCH_PORTAL_CONFIGURATION_FAILURE:
       return {
@@ -47,6 +50,8 @@ const portalConfiguration = (state = initialState, action) => {
         enterpriseSlug: null,
         enterpriseLogo: null,
         enableCodeManagementScreen: false,
+        enableReportingConfigScreen: false,
+        enableSubscriptionManagementScreen: false,
       };
     case CLEAR_PORTAL_CONFIGURATION:
       return {
@@ -56,6 +61,8 @@ const portalConfiguration = (state = initialState, action) => {
         enterpriseSlug: null,
         enterpriseLogo: null,
         enableCodeManagementScreen: false,
+        enableReportingConfigScreen: false,
+        enableSubscriptionManagementScreen: false,
       };
     default:
       return state;

--- a/src/data/reducers/portalConfiguration.test.js
+++ b/src/data/reducers/portalConfiguration.test.js
@@ -13,6 +13,8 @@ const initialState = {
   enterpriseSlug: null,
   enterpriseLogo: null,
   enableCodeManagementScreen: false,
+  enableReportingConfigScreen: false,
+  enableSubscriptionManagementScreen: false,
 };
 
 const enterpriseData = {
@@ -25,6 +27,8 @@ const enterpriseData = {
     logo: 'https://s3...',
   },
   enable_portal_code_management_screen: true,
+  enable_portal_reporting_config_screen: true,
+  enable_portal_subscription_management_screen: true,
 };
 
 describe('portalConfiguration reducer', () => {
@@ -40,6 +44,8 @@ describe('portalConfiguration reducer', () => {
       enterpriseSlug: enterpriseData.slug,
       enterpriseLogo: enterpriseData.branding_configuration.logo,
       enableCodeManagementScreen: enterpriseData.enable_portal_code_management_screen,
+      enableReportingConfigScreen: enterpriseData.enable_portal_reporting_config_screen,
+      enableSubscriptionManagementScreen: enterpriseData.enable_portal_subscription_management_screen, // eslint-disable-line max-len
     };
     expect(portalConfiguration(undefined, {
       type: FETCH_PORTAL_CONFIGURATION_SUCCESS,


### PR DESCRIPTION
This PR adds a new tab for Subscription Management to the admin dashboard, based on a new feature flag and the enterprise customer configuration from https://github.com/edx/edx-enterprise/pull/724. For now, the route just loads the code management screen component, which will be replaced later.