### PR TITLE
Reduce logo image sizing to reduce unneeded whitespace in header/footer

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -8,7 +8,9 @@ footer {
             padding: 0 1.5rem;
 
             img {
+                max-height: 60px;
                 max-width: 100px;
+                width: auto;
             }
 
             &:first-child {

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -2,7 +2,11 @@ header {
     border-bottom: 1px solid #d4d4d4;
 
     .navbar-brand {
-        max-width: 100px;
+        img {
+            max-height: 60px;
+            max-width: 100px;
+            width: auto;
+        }
     }
     
     .dropdown > button {

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -43,7 +43,7 @@ class Header extends React.Component {
     const { email, hasSidebarToggle } = this.props;
     return (
       <header className="container-fluid">
-        <nav className="navbar px-0 justify-content-between">
+        <nav className="navbar px-0 py-1 justify-content-between">
           <div>
             {hasSidebarToggle && <SidebarToggle />}
             <Link

--- a/src/containers/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/containers/Header/__snapshots__/Header.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`<Header /> does not render profile image or dropdown if unauthenticated
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -29,7 +29,7 @@ exports[`<Header /> renders default profile image correctly 1`] = `
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -93,7 +93,7 @@ exports[`<Header /> renders edX logo correctly 1`] = `
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -117,7 +117,7 @@ exports[`<Header /> renders enterprise logo correctly 1`] = `
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -141,7 +141,7 @@ exports[`<Header /> renders profile image correctly 1`] = `
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -200,7 +200,7 @@ exports[`<Header /> renders sidebar toggle correctly does not show toggle 1`] = 
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <a
@@ -224,7 +224,7 @@ exports[`<Header /> renders sidebar toggle correctly does show toggle 1`] = `
   className="container-fluid"
 >
   <nav
-    className="navbar px-0 justify-content-between"
+    className="navbar px-0 py-1 justify-content-between"
   >
     <div>
       <button


### PR DESCRIPTION
Currently, the logo images for the Admin Dash can take up a lot of space in the header and footer, creating a lot of unnecessary whitespace. 

**Current:**

![image](https://user-images.githubusercontent.com/2828721/78266941-6c795080-74d4-11ea-9cdc-2c336e3080c5.png)

This PR sets a `max-height` on the logos in the header/footer so the image sizes are more constrained for less unnecessary whitespace.

**Updated:**

![image](https://user-images.githubusercontent.com/2828721/78267286-caa63380-74d4-11ea-8693-9ec1ede39793.png)
