### PR TITLE
Refactor number cards layout for IE11/Edge support

### DIFF
--- a/src/components/Admin/Admin.scss
+++ b/src/components/Admin/Admin.scss
@@ -1,23 +1,3 @@
-.row.equal-col-height {
-    display: flex;
-    flex-wrap: wrap;
-
-    > [class*="col-"] {
-        display: flex;
-
-        > div {
-            position: relative;
-            display: flex;
-            flex: 1;
-            flex-direction: column;
-        }
-    }
-
-    .card {
-        flex: 1;
-    }
-}
-
 .table-title {
     display: inline-block;
     vertical-align: middle;

--- a/src/components/Admin/AdminCards.jsx
+++ b/src/components/Admin/AdminCards.jsx
@@ -64,7 +64,7 @@ class AdminCards extends React.Component {
 
     return (
       <div
-        className="col-xs-12 col-md-6 col-xl-3 mb-3"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
         key={cardKey}
       >
         <NumberCard
@@ -93,12 +93,12 @@ class AdminCards extends React.Component {
       enrolledLearners,
     };
 
-    return (
-      <div className="row mt-3 equal-col-height">
-        {Object.keys(this.cards).map(cardKey =>
-          this.renderCard({ title: data[cardKey], cardKey }))}
-      </div>
-    );
+    return Object.keys(this.cards).map(cardKey => (
+      this.renderCard({
+        title: data[cardKey],
+        cardKey,
+      })
+    ));
   }
 }
 

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -50,10 +50,10 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
-        className="col"
+        className="col mt-3"
       >
         <div
           className="loading d-flex align-items-center justify-content-center overview mt-3"
@@ -129,7 +129,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -163,437 +163,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon22"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon22"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon23"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon24"
+                      className="fa fa-caret-down"
+                      id="Icon23"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon25"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon24"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon26"
+                      className="fa fa-caret-down"
+                      id="Icon25"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon27"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon26"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon28"
+                      className="fa fa-caret-down"
+                      id="Icon27"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon29"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon28"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon29"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -708,7 +708,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -742,437 +742,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon72"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon72"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon73"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon74"
+                      className="fa fa-caret-down"
+                      id="Icon73"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon75"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon74"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon76"
+                      className="fa fa-caret-down"
+                      id="Icon75"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon77"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon76"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon78"
+                      className="fa fa-caret-down"
+                      id="Icon77"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon79"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon78"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon79"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -1287,7 +1287,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -1321,437 +1321,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon82"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon82"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon83"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon84"
+                      className="fa fa-caret-down"
+                      id="Icon83"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon85"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon84"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon86"
+                      className="fa fa-caret-down"
+                      id="Icon85"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon87"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon86"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon88"
+                      className="fa fa-caret-down"
+                      id="Icon87"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon89"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon88"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon89"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -1871,7 +1871,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -1905,437 +1905,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon92"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon92"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon93"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon94"
+                      className="fa fa-caret-down"
+                      id="Icon93"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon95"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon94"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon96"
+                      className="fa fa-caret-down"
+                      id="Icon95"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon97"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon96"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon98"
+                      className="fa fa-caret-down"
+                      id="Icon97"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon99"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon98"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon99"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -2517,7 +2517,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -2551,437 +2551,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon1"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon1"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon2"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon3"
+                      className="fa fa-caret-down"
+                      id="Icon2"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon4"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon3"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon5"
+                      className="fa fa-caret-down"
+                      id="Icon4"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon6"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon5"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon7"
+                      className="fa fa-caret-down"
+                      id="Icon6"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon8"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon7"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon8"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -3163,7 +3163,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -3197,437 +3197,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon62"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon62"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon63"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon64"
+                      className="fa fa-caret-down"
+                      id="Icon63"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon65"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon64"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon66"
+                      className="fa fa-caret-down"
+                      id="Icon65"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon67"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon66"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon68"
+                      className="fa fa-caret-down"
+                      id="Icon67"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon69"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon68"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon69"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -3747,7 +3747,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -3781,437 +3781,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon52"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon52"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon53"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon54"
+                      className="fa fa-caret-down"
+                      id="Icon53"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon55"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon54"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon56"
+                      className="fa fa-caret-down"
+                      id="Icon55"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon57"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon56"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon58"
+                      className="fa fa-caret-down"
+                      id="Icon57"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon59"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon58"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon59"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -4331,7 +4331,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -4365,437 +4365,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon32"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon32"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon33"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon34"
+                      className="fa fa-caret-down"
+                      id="Icon33"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon35"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon34"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon36"
+                      className="fa fa-caret-down"
+                      id="Icon35"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon37"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon36"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon38"
+                      className="fa fa-caret-down"
+                      id="Icon37"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon39"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon38"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon39"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -4913,7 +4913,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -4947,437 +4947,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon12"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon12"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon13"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon14"
+                      className="fa fa-caret-down"
+                      id="Icon13"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon15"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon14"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon16"
+                      className="fa fa-caret-down"
+                      id="Icon15"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon17"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon16"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon18"
+                      className="fa fa-caret-down"
+                      id="Icon17"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon19"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon18"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon19"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -5492,7 +5492,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -5526,437 +5526,437 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
       className="row"
     >
       <div
-        className="col"
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
       >
         <div
-          className="row mt-3 equal-col-height"
+          className="number-card w-100 has-details"
         >
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card"
           >
             <div
-              className="number-card has-details"
+              className="card-body"
             >
-              <div
-                className="card"
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
               >
-                <div
-                  className="card-body"
-                >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
-                  >
-                    <span>
-                      3
-                    </span>
-                    <span
-                      aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-users"
-                      id="Icon42"
-                    />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    total number of learners registered
-                  </p>
-                </div>
-              </div>
-              <div
-                className="card-footer"
+                <span>
+                  3
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-users"
+                  id="Icon42"
+                />
+              </h5>
+              <p
+                className="card-text"
               >
-                <div
-                  className="footer-title"
-                >
-                  <button
-                    aria-controls="footer-body-numberOfUsers"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon43"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-numberOfUsers"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/registered-unenrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Which learners are registered but not yet enrolled in any courses?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+                total number of learners registered
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-numberOfUsers"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-check"
-                      id="Icon44"
+                      className="fa fa-caret-down"
+                      id="Icon43"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    learners enrolled in at least one course
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-numberOfUsers"
+            >
+              <a
+                className="btn btn-link"
+                href="/registered-unenrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-enrolledLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon45"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Which learners are registered but not yet enrolled in any courses?
+                  </span>
                 </div>
-                <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-enrolledLearners"
-                >
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses are learners enrolled in?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/enrolled-learners-inactive-courses"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who is no longer enrolled in a current course?
-                      </span>
-                    </div>
-                  </a>
-                </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-check"
+                  id="Icon44"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                learners enrolled in at least one course
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-enrolledLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-eye"
-                      id="Icon46"
+                      className="fa fa-caret-down"
+                      id="Icon45"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    active learners in the past week
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-enrolledLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-activeLearners"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon47"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    How many courses are learners enrolled in?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/enrolled-learners-inactive-courses"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-activeLearners"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/learners-active-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who are my top active learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a week?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/learners-inactive-month"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who has not been active for over a month?
-                      </span>
-                    </div>
-                  </a>
+                    Who is no longer enrolled in a current course?
+                  </span>
                 </div>
-              </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-eye"
+                  id="Icon46"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                active learners in the past week
+              </p>
             </div>
           </div>
           <div
-            className="col-xs-12 col-md-6 col-xl-3 mb-3"
+            className="card-footer"
           >
             <div
-              className="number-card has-details"
+              className="footer-title"
             >
-              <div
-                className="card"
+              <button
+                aria-controls="footer-body-activeLearners"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
                 <div
-                  className="card-body"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <h5
-                    className="card-title d-flex align-items-center justify-content-between"
+                  <div
+                    className="details-btn-text"
                   >
-                    <span>
-                      1
-                    </span>
+                    Details
+                  </div>
+                  <div>
                     <span
                       aria-hidden={true}
-                      className="d-flex align-items-center justify-content-center fa fa-trophy"
-                      id="Icon48"
+                      className="fa fa-caret-down"
+                      id="Icon47"
                     />
-                  </h5>
-                  <p
-                    className="card-text"
-                  >
-                    course completions
-                  </p>
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="card-footer"
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-activeLearners"
+            >
+              <a
+                className="btn btn-link"
+                href="/learners-active-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
                 <div
-                  className="footer-title"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <button
-                    aria-controls="footer-body-courseCompletions"
-                    aria-expanded={false}
-                    className="btn toggle-collapse btn-link btn-block"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="details-btn-text"
-                      >
-                        Details
-                      </span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon49"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Show details
-                      </span>
-                    </div>
-                  </button>
+                    Who are my top active learners?
+                  </span>
                 </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="footer-body mt-1 d-none"
-                  id="footer-body-courseCompletions"
+                  className="d-flex justify-content-between align-items-center"
                 >
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
+                  <span
+                    className="label"
                   >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        How many courses have been completed by learners?
-                      </span>
-                    </div>
-                  </a>
-                  <a
-                    className="btn btn-link"
-                    href="/completed-learners-week"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                  >
-                    <div
-                      className="d-flex justify-content-between align-items-center"
-                    >
-                      <span
-                        className="label"
-                      >
-                        Who completed a course in the past week?
-                      </span>
-                    </div>
-                  </a>
+                    Who has not been active for over a week?
+                  </span>
                 </div>
-              </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/learners-inactive-month"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who has not been active for over a month?
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+      >
+        <div
+          className="number-card w-100 has-details"
+        >
+          <div
+            className="card"
+          >
+            <div
+              className="card-body"
+            >
+              <h5
+                className="card-title d-flex align-items-center justify-content-between"
+              >
+                <span>
+                  1
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="d-flex align-items-center justify-content-center fa fa-trophy"
+                  id="Icon48"
+                />
+              </h5>
+              <p
+                className="card-text"
+              >
+                course completions
+              </p>
+            </div>
+          </div>
+          <div
+            className="card-footer"
+          >
+            <div
+              className="footer-title"
+            >
+              <button
+                aria-controls="footer-body-courseCompletions"
+                aria-expanded={false}
+                className="btn toggle-collapse btn-link btn-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <div
+                    className="details-btn-text"
+                  >
+                    Details
+                  </div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-caret-down"
+                      id="Icon49"
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Show details
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div
+              className="footer-body mt-1 d-none"
+              id="footer-body-courseCompletions"
+            >
+              <a
+                className="btn btn-link"
+                href="/completed-learners"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    How many courses have been completed by learners?
+                  </span>
+                </div>
+              </a>
+              <a
+                className="btn btn-link"
+                href="/completed-learners-week"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="d-flex justify-content-between align-items-center"
+                >
+                  <span
+                    className="label"
+                  >
+                    Who completed a course in the past week?
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
         </div>
@@ -6076,7 +6076,7 @@ exports[`<Admin /> renders correctly with error state 1`] = `
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -6107,40 +6107,44 @@ exports[`<Admin /> renders correctly with error state 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
-        className="col"
+        className="col mt-3"
       >
         <div
-          className="mt-3 alert fade alert-danger show"
-          hidden={false}
-          role="alert"
+          className="col"
         >
           <div
-            className="alert-dialog"
+            className="alert fade alert-danger show"
+            hidden={false}
+            role="alert"
           >
             <div
-              className="d-flex"
+              className="alert-dialog"
             >
               <div
-                className="icon mr-2"
+                className="d-flex"
               >
-                <span
-                  aria-hidden={true}
-                  className="fa fa-times-circle"
-                  id="Icon103"
-                />
-              </div>
-              <div
-                className="message"
-              >
-                <span
-                  className="title"
+                <div
+                  className="icon mr-2"
                 >
-                  Unable to load overview
-                </span>
-                Try refreshing your screen (Network Error)
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-times-circle"
+                    id="Icon103"
+                  />
+                </div>
+                <div
+                  className="message"
+                >
+                  <span
+                    className="title"
+                  >
+                    Unable to load overview
+                  </span>
+                  Try refreshing your screen (Network Error)
+                </div>
               </div>
             </div>
           </div>
@@ -6214,7 +6218,7 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
           <h1
             className={null}
           >
-            Learner and Progress Report
+            Learner Progress Report
           </h1>
         </div>
         <div
@@ -6245,10 +6249,10 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
-        className="col"
+        className="col mt-3"
       >
         <div
           className="loading d-flex align-items-center justify-content-center overview mt-3"

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
       className="row mt-3"
     >
       <div
-        className="col mt-3"
+        className="col"
       >
         <div
           className="loading d-flex align-items-center justify-content-center overview mt-3"
@@ -160,7 +160,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -739,7 +739,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -1318,7 +1318,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -1902,7 +1902,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -2548,7 +2548,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -3194,7 +3194,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -3778,7 +3778,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -4362,7 +4362,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -4944,7 +4944,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -5523,7 +5523,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
       </div>
     </div>
     <div
-      className="row"
+      className="row mt-3"
     >
       <div
         className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
@@ -6110,41 +6110,37 @@ exports[`<Admin /> renders correctly with error state 1`] = `
       className="row mt-3"
     >
       <div
-        className="col mt-3"
+        className="col"
       >
         <div
-          className="col"
+          className="alert fade alert-danger show"
+          hidden={false}
+          role="alert"
         >
           <div
-            className="alert fade alert-danger show"
-            hidden={false}
-            role="alert"
+            className="alert-dialog"
           >
             <div
-              className="alert-dialog"
+              className="d-flex"
             >
               <div
-                className="d-flex"
+                className="icon mr-2"
               >
-                <div
-                  className="icon mr-2"
+                <span
+                  aria-hidden={true}
+                  className="fa fa-times-circle"
+                  id="Icon103"
+                />
+              </div>
+              <div
+                className="message"
+              >
+                <span
+                  className="title"
                 >
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-times-circle"
-                    id="Icon103"
-                  />
-                </div>
-                <div
-                  className="message"
-                >
-                  <span
-                    className="title"
-                  >
-                    Unable to load overview
-                  </span>
-                  Try refreshing your screen (Network Error)
-                </div>
+                  Unable to load overview
+                </span>
+                Try refreshing your screen (Network Error)
               </div>
             </div>
           </div>
@@ -6252,7 +6248,7 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
       className="row mt-3"
     >
       <div
-        className="col mt-3"
+        className="col"
       >
         <div
           className="loading d-flex align-items-center justify-content-center overview mt-3"

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -266,7 +266,6 @@ class Admin extends React.Component {
   renderErrorMessage() {
     return (
       <StatusAlert
-        className="mt-3"
         alertType="danger"
         iconClassName="fa fa-times-circle"
         title="Unable to load overview"
@@ -338,25 +337,29 @@ class Admin extends React.Component {
         {!loading && !error && !this.hasAnalyticsData() ? this.renderLoadingMessage() : (
           <React.Fragment>
             <main role="main">
-              <Helmet>
-                <title>Learner and Progress Report</title>
-              </Helmet>
-              <Hero title="Learner and Progress Report" />
+              <Helmet title="Learner Progress Report" />
+              <Hero title="Learner Progress Report" />
               <div className="container-fluid">
                 <div className="row mt-4">
                   <div className="col">
                     <H2>Overview</H2>
                   </div>
                 </div>
-                <div className="row">
-                  <div className="col">
-                    {error && this.renderErrorMessage()}
-                    {loading && this.renderLoadingMessage()}
-                    {!loading && !error && this.hasAnalyticsData() &&
-                      <AdminCards />
-                    }
+                {(error || loading) && (
+                  <div className="row mt-3">
+                    {(error || loading) && (
+                      <div className="col mt-3">
+                        {error && this.renderErrorMessage()}
+                        {loading && this.renderLoadingMessage()}
+                      </div>
+                    )}
                   </div>
-                </div>
+                )}
+                {!error && !loading && (
+                  <div className="row">
+                    <AdminCards />
+                  </div>
+                )}
                 <div className="row mt-4">
                   <div className="col">
                     <H2 className="table-title">{tableMetadata.title}</H2>

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -345,21 +345,16 @@ class Admin extends React.Component {
                     <H2>Overview</H2>
                   </div>
                 </div>
-                {(error || loading) && (
-                  <div className="row mt-3">
-                    {(error || loading) && (
-                      <div className="col mt-3">
-                        {error && this.renderErrorMessage()}
-                        {loading && this.renderLoadingMessage()}
-                      </div>
-                    )}
-                  </div>
-                )}
-                {!error && !loading && (
-                  <div className="row">
+                <div className="row mt-3">
+                  {(error || loading) ? (
+                    <div className="col">
+                      {error && this.renderErrorMessage()}
+                      {loading && this.renderLoadingMessage()}
+                    </div>
+                  ) : (
                     <AdminCards />
-                  </div>
-                )}
+                  )}
+                </div>
                 <div className="row mt-4">
                   <div className="col">
                     <H2 className="table-title">{tableMetadata.title}</H2>

--- a/src/components/NumberCard/NumberCard.scss
+++ b/src/components/NumberCard/NumberCard.scss
@@ -16,6 +16,8 @@ $number-card-box-shadow: 0 .125rem .25rem rgba(0,0,0,.075);
     }
 
     @include media-breakpoint-up($viewport-size-details-overlay) {
+        flex: 1 1 auto;
+
         &.has-details {
             margin-bottom: 53px; // height of collapsed .card-footer
         }

--- a/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
+++ b/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<NumberCard /> renders correctly with detail actions 1`] = `
 <div
-  className="number-card has-details"
+  className="number-card w-100 has-details"
 >
   <div
     className="card test-class"
@@ -47,21 +47,23 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
         <div
           className="d-flex justify-content-between align-items-center"
         >
-          <span
+          <div
             className="details-btn-text"
           >
             Details
-          </span>
-          <span
-            aria-hidden={true}
-            className="fa fa-caret-down"
-            id="Icon3"
-          />
-          <span
-            className="sr-only"
-          >
-            Show details
-          </span>
+          </div>
+          <div>
+            <span
+              aria-hidden={true}
+              className="fa fa-caret-down"
+              id="Icon3"
+            />
+            <span
+              className="sr-only"
+            >
+              Show details
+            </span>
+          </div>
         </div>
       </button>
     </div>
@@ -108,7 +110,7 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
 
 exports[`<NumberCard /> renders correctly without detail actions 1`] = `
 <div
-  className="number-card"
+  className="number-card w-100"
 >
   <div
     className="card test-class"

--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -179,7 +179,7 @@ class NumberCard extends React.Component {
     return (
       <div
         ref={(node) => { this.containerRef = node; }}
-        className={classNames('number-card', {
+        className={classNames('number-card w-100', {
           'has-details': detailActions,
         })}
       >
@@ -213,17 +213,21 @@ class NumberCard extends React.Component {
                 aria-controls={`footer-body-${id}`}
               >
                 <div className="d-flex justify-content-between align-items-center">
-                  <span className="details-btn-text">{detailsExpanded ? 'Detailed breakdown' : 'Details'}</span>
-                  <Icon
-                    className={classNames(
-                      'fa',
-                      {
-                        'fa-caret-down': !detailsExpanded,
-                        'fa-close': detailsExpanded,
-                      },
-                    )}
-                    screenReaderText={detailsExpanded ? 'Close details' : 'Show details'}
-                  />
+                  <div className="details-btn-text">
+                    {detailsExpanded ? 'Detailed breakdown' : 'Details'}
+                  </div>
+                  <div>
+                    <Icon
+                      className={classNames(
+                        'fa',
+                        {
+                          'fa-caret-down': !detailsExpanded,
+                          'fa-close': detailsExpanded,
+                        },
+                      )}
+                      screenReaderText={detailsExpanded ? 'Close details' : 'Show details'}
+                    />
+                  </div>
                 </div>
               </Button>
             </div>


### PR DESCRIPTION
IE11/Edge does not currently support the row of number cards. This PR uses Boostrap classes to ensure cross-browser compatibility.

## Before

![image](https://user-images.githubusercontent.com/2828721/78846351-7e2d8d00-79d9-11ea-9e1d-79f66b6c56e2.png)




## After
![image](https://user-images.githubusercontent.com/2828721/78846466-e0868d80-79d9-11ea-9237-b2654e3e015f.png)

