### PR TITLE
Always show "Add Users" button but conditionally render "Remind all"; refresh subscription data after revoking a user

### DIFF
--- a/src/components/ActionButtonWithModal/index.jsx
+++ b/src/components/ActionButtonWithModal/index.jsx
@@ -29,7 +29,7 @@ class ActionButtonWithModal extends React.Component {
 }
 
 ActionButtonWithModal.propTypes = {
-  buttonLabel: PropTypes.string.isRequired,
+  buttonLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   buttonClassName: PropTypes.string.isRequired,
   renderModal: PropTypes.func.isRequired,
 };

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -161,7 +161,7 @@ class EnterpriseApp extends React.Component {
                     <Route
                       key="subscription-management"
                       exact
-                      path={`${baseUrl}/admin/subscription`}
+                      path={`${baseUrl}/admin/subscriptions`}
                       render={routeProps =>
                         <SubscriptionManagementPage {...routeProps} />
                       }

--- a/src/components/LicenseRemindModal/index.jsx
+++ b/src/components/LicenseRemindModal/index.jsx
@@ -94,9 +94,10 @@ class LicenseRemindModal extends React.Component {
       options.email = user.emailAddress;
     }
 
-    return sendLicenseReminder(options).then((response) => {
-      this.props.onSuccess(response);
-    })
+    return sendLicenseReminder(options)
+      .then((response) => {
+        this.props.onSuccess(response);
+      })
       .catch((error) => {
         throw new SubmissionError({
           _error: [error.message],
@@ -181,9 +182,11 @@ class LicenseRemindModal extends React.Component {
     return (
       <React.Fragment>
         <span className="d-block">{title}</span>
-        <small>
-          {subtitle}
-        </small>
+        {subtitle && (
+          <small>
+            {subtitle}
+          </small>
+        )}
       </React.Fragment>
     );
   }
@@ -225,6 +228,7 @@ LicenseRemindModal.defaultProps = {
   isBulkRemind: false,
   user: {},
   pendingUsersCount: 0,
+  subtitle: null,
 };
 LicenseRemindModal.propTypes = {
   // props From redux-form
@@ -236,10 +240,10 @@ LicenseRemindModal.propTypes = {
   initialize: PropTypes.func.isRequired,
   // custom props
   title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired,
   sendLicenseReminder: PropTypes.func.isRequired,
+  subtitle: PropTypes.string,
   isBulkRemind: PropTypes.bool,
   pendingUsersCount: PropTypes.number,
   user: PropTypes.shape({

--- a/src/components/LicenseRevokeModal/index.jsx
+++ b/src/components/LicenseRevokeModal/index.jsx
@@ -5,6 +5,7 @@ import { Button, Icon, Modal } from '@edx/paragon';
 
 import StatusAlert from '../StatusAlert';
 
+import NewRelicService from '../../data/services/NewRelicService';
 
 class LicenseRevokeModal extends React.Component {
   constructor(props) {
@@ -61,8 +62,7 @@ class LicenseRevokeModal extends React.Component {
           await fetchSubscriptionUsers({ searchQuery });
           this.props.onSuccess(response);
         } catch (error) {
-          // TODO: log error in NewRelic
-          console.log(error); // eslint-disable-line no-console
+          NewRelicService.logAPIErrorResponse(error);
         }
       })
       .catch((error) => {

--- a/src/components/LicenseRevokeModal/index.jsx
+++ b/src/components/LicenseRevokeModal/index.jsx
@@ -90,7 +90,7 @@ class LicenseRevokeModal extends React.Component {
   }
 
   renderErrorMessage() {
-    const modeErrors = {
+    const modalErrors = {
       revoke: 'Unable to revoke license',
     };
     const { error } = this.props;
@@ -103,7 +103,7 @@ class LicenseRevokeModal extends React.Component {
         <StatusAlert
           alertType="danger"
           iconClassName="fa fa-times-circle"
-          title={modeErrors.revoke}
+          title={modalErrors.revoke}
           message={error.length > 1 ? (
             <ul className="m-0 pl-4">
               {error.map(message => <li key={message}>{message}</li>)}
@@ -117,14 +117,7 @@ class LicenseRevokeModal extends React.Component {
   }
 
   renderTitle() {
-    return (
-      <React.Fragment>
-        <span>
-          <i className="fa fa-exclamation-circle" aria-hidden="true" />
-          <small> Are you sure you want to revoke access?</small>
-        </span>
-      </React.Fragment>
-    );
+    return <small>Are you sure you want to revoke access?</small>;
   }
 
   render() {

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -67,7 +67,7 @@ class Sidebar extends React.Component {
       },
       {
         title: 'Subscription Management',
-        to: `${baseUrl}/admin/subscription`,
+        to: `${baseUrl}/admin/subscriptions`,
         iconClassName: 'fa-credit-card',
         hidden: !features.SUBSCRIPTION_MANAGEMENT || !enableSubscriptionManagementScreen,
       },

--- a/src/components/subscriptions/LicenseActions.jsx
+++ b/src/components/subscriptions/LicenseActions.jsx
@@ -8,15 +8,7 @@ import LicenseRevokeModal from '../../containers/LicenseRevokeModal';
 import { StatusContext } from './SubscriptionManagementPage';
 
 export default function LicenseAction({ user }) {
-  const setStatus = useContext(StatusContext);
-
-  const setSuccessStatus = (message) => {
-    setStatus({
-      visible: true,
-      alertType: 'success',
-      message,
-    });
-  };
+  const { setSuccessStatus } = useContext(StatusContext);
 
   const licenseActions = useMemo(
     () => {
@@ -27,7 +19,10 @@ export default function LicenseAction({ user }) {
             // eslint-disable-next-line no-console
             handleClick: closeModal => (<LicenseRevokeModal
               user={user}
-              onSuccess={() => setSuccessStatus('Successfully revoked license')}
+              onSuccess={() => setSuccessStatus({
+                visible: true,
+                message: 'Successfully revoked license',
+              })}
               onClose={() => {
                 closeModal();
               }}
@@ -37,26 +32,35 @@ export default function LicenseAction({ user }) {
           return [{
             text: 'Remind',
             // eslint-disable-next-line no-console
-            handleClick: closeModal => (<LicenseRemindModal
-              user={user}
-              isBulkRemind={false}
-              title="Remind User"
-              subtitle=""
-              onSuccess={() => setSuccessStatus('Successfully sent reminder(s)')}
-              onClose={() => {
-                closeModal();
-              }}
-            />),
+            handleClick: closeModal => (
+              <LicenseRemindModal
+                user={user}
+                isBulkRemind={false}
+                title="Remind User"
+                onSuccess={() => setSuccessStatus({
+                  visible: true,
+                  message: 'Successfully sent reminder(s)',
+                })}
+                onClose={() => {
+                  closeModal();
+                }}
+              />
+            ),
           }, {
             text: 'Revoke',
             // eslint-disable-next-line no-console
-            handleClick: closeModal => (<LicenseRevokeModal
-              user={user}
-              onSuccess={() => setSuccessStatus('Successfully revoked license')}
-              onClose={() => {
-                closeModal();
-              }}
-            />),
+            handleClick: closeModal => (
+              <LicenseRevokeModal
+                user={user}
+                onSuccess={() => setSuccessStatus({
+                  visible: true,
+                  message: 'Successfully revoked license',
+                })}
+                onClose={() => {
+                  closeModal();
+                }}
+              />
+            ),
           }];
         default:
           return [{ text: '-' }];

--- a/src/components/subscriptions/LicenseActions.jsx
+++ b/src/components/subscriptions/LicenseActions.jsx
@@ -1,37 +1,51 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
-import './styles/LicenseActions.scss';
 import ActionButtonWithModal from '../ActionButtonWithModal';
 import LicenseRemindModal from '../../containers/LicenseRemindModal';
 import LicenseRevokeModal from '../../containers/LicenseRevokeModal';
 import { StatusContext } from './SubscriptionManagementPage';
 
+import { SubscriptionContext } from './SubscriptionData';
+
+import { ACTIVE, ASSIGNED } from './constants';
+
+import './styles/LicenseActions.scss';
+
 export default function LicenseAction({ user }) {
   const { setSuccessStatus } = useContext(StatusContext);
+  const {
+    fetchSubscriptionDetails,
+    fetchSubscriptionUsers,
+    searchQuery,
+    activeTab,
+  } = useContext(SubscriptionContext);
 
   const licenseActions = useMemo(
     () => {
       switch (user.licenseStatus) {
-        case 'active':
+        case ACTIVE:
           return [{
+            key: 'revoke-btn',
             text: 'Revoke',
-            // eslint-disable-next-line no-console
-            handleClick: closeModal => (<LicenseRevokeModal
-              user={user}
-              onSuccess={() => setSuccessStatus({
-                visible: true,
-                message: 'Successfully revoked license',
-              })}
-              onClose={() => {
-                closeModal();
-              }}
-            />),
+            handleClick: closeModal => (
+              <LicenseRevokeModal
+                user={user}
+                onSuccess={() => setSuccessStatus({
+                  visible: true,
+                  message: 'Successfully revoked license',
+                })}
+                onClose={() => closeModal()}
+                fetchSubscriptionDetails={fetchSubscriptionDetails}
+                fetchSubscriptionUsers={fetchSubscriptionUsers}
+                searchQuery={searchQuery}
+              />
+            ),
           }];
-        case 'assigned':
+        case ASSIGNED:
           return [{
+            key: 'remind-btn',
             text: 'Remind',
-            // eslint-disable-next-line no-console
             handleClick: closeModal => (
               <LicenseRemindModal
                 user={user}
@@ -47,8 +61,8 @@ export default function LicenseAction({ user }) {
               />
             ),
           }, {
+            key: 'revoke-btn',
             text: 'Revoke',
-            // eslint-disable-next-line no-console
             handleClick: closeModal => (
               <LicenseRevokeModal
                 user={user}
@@ -56,34 +70,37 @@ export default function LicenseAction({ user }) {
                   visible: true,
                   message: 'Successfully revoked license',
                 })}
-                onClose={() => {
-                  closeModal();
-                }}
+                onClose={() => closeModal()}
+                fetchSubscriptionDetails={fetchSubscriptionDetails}
+                fetchSubscriptionUsers={fetchSubscriptionUsers}
+                searchQuery={searchQuery}
               />
             ),
           }];
         default:
-          return [{ text: '-' }];
+          return [{ key: 'no-actions-here', text: '-' }];
       }
     },
-    [user],
+    [user, activeTab, searchQuery],
   );
+
   return (
     <div className="license-actions">
-      {licenseActions.map((licenseAction) => {
-        if (licenseAction.handleClick) {
-          return (
+      {licenseActions.map(({ handleClick, text, key }) => (
+        <React.Fragment key={key}>
+          {handleClick ? (
             <ActionButtonWithModal
-              buttonLabel={licenseAction.text}
+              buttonLabel={text}
               buttonClassName="btn btn-link btn-sm p-0"
               renderModal={({ closeModal }) => (
-                licenseAction.handleClick(closeModal)
+                handleClick(closeModal)
               )}
             />
-          );
-        }
-        return licenseAction.text;
-      })}
+          ) : (
+            text
+          )}
+        </React.Fragment>
+      ))}
     </div>
   );
 }

--- a/src/components/subscriptions/RemindUsersButton.jsx
+++ b/src/components/subscriptions/RemindUsersButton.jsx
@@ -4,21 +4,25 @@ import PropTypes from 'prop-types';
 import LicenseRemindModal from '../../containers/LicenseRemindModal';
 import ActionButtonWithModal from '../ActionButtonWithModal';
 
-const RemindUserButton = ({
+const RemindUsersButton = ({
   onSuccess,
   onClose,
   pendingUsersCount,
   isBulkRemind,
 }) => (
   <ActionButtonWithModal
-    buttonLabel="Remind all"
-    buttonClassName="btn btn-primary float-right"
+    buttonLabel={
+      <React.Fragment>
+        <i className="fa fa-refresh mr-2" aria-hidden />
+        Remind all ({pendingUsersCount})
+      </React.Fragment>
+    }
+    buttonClassName="btn btn-link"
     renderModal={({ closeModal }) => (
       <LicenseRemindModal
         pendingUsersCount={pendingUsersCount}
         isBulkRemind={isBulkRemind}
         title="Remind Users"
-        subtitle=""
         onSuccess={onSuccess}
         onClose={() => {
           closeModal();
@@ -31,16 +35,16 @@ const RemindUserButton = ({
   />
 );
 
-RemindUserButton.propTypes = {
+RemindUsersButton.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   pendingUsersCount: PropTypes.number,
   isBulkRemind: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
 };
 
-RemindUserButton.defaultProps = {
+RemindUsersButton.defaultProps = {
   onClose: null,
   pendingUsersCount: null,
 };
 
-export default RemindUserButton;
+export default RemindUsersButton;

--- a/src/components/subscriptions/RemindUsersButton.jsx
+++ b/src/components/subscriptions/RemindUsersButton.jsx
@@ -17,7 +17,7 @@ const RemindUsersButton = ({
         Remind all ({pendingUsersCount})
       </React.Fragment>
     }
-    buttonClassName="btn btn-link"
+    buttonClassName="btn btn-link p-0"
     renderModal={({ closeModal }) => (
       <LicenseRemindModal
         pendingUsersCount={pendingUsersCount}

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -12,6 +12,9 @@ import {
   TAB_LICENSED_USERS,
   TAB_PENDING_USERS,
   TAB_DEACTIVATED_USERS,
+  ACTIVE,
+  ASSIGNED,
+  DEACTIVATED,
 } from './constants';
 
 export const SubscriptionContext = createContext();
@@ -50,31 +53,41 @@ export default function SubscriptionData({ children }) {
       searchQuery,
       activeTab,
       setActiveTab,
+      fetchSubscriptionDetails: () => (
+        fetchSubscriptionDetails()
+          .then((response) => {
+            setDetails(response);
+          })
+          // eslint-disable-next-line no-console
+          .catch(error => console.log(error))
+      ),
       fetchSubscriptionUsers: (options = {}) => {
         const licenseStatusByTab = {
-          [TAB_LICENSED_USERS]: 'active',
-          [TAB_PENDING_USERS]: 'assigned',
-          [TAB_DEACTIVATED_USERS]: 'deactivated',
+          [TAB_LICENSED_USERS]: ACTIVE,
+          [TAB_PENDING_USERS]: ASSIGNED,
+          [TAB_DEACTIVATED_USERS]: DEACTIVATED,
         };
 
         setSearchQuery(options.searchQuery);
 
-        Promise.all([
-          fetchSubscriptionUsersOverview(options),
-          fetchSubscriptionUsers({
-            statusFilter: licenseStatusByTab[activeTab],
-            ...options,
-          }),
-        ])
-          .then((responses) => {
-            setOverview(responses[0]);
-            setUsers(responses[1]);
-          })
-          // eslint-disable-next-line no-console
-          .catch(error => console.log(error));
+        return (
+          Promise.all([
+            fetchSubscriptionUsersOverview(options),
+            fetchSubscriptionUsers({
+              ...options,
+              statusFilter: licenseStatusByTab[activeTab],
+            }),
+          ])
+            .then((responses) => {
+              setOverview(responses[0]);
+              setUsers(responses[1]);
+            })
+            // eslint-disable-next-line no-console
+            .catch(error => console.log(error))
+        );
       },
     }),
-    [details, users, activeTab, setActiveTab],
+    [details, overview, users, activeTab],
   );
 
   const hasInitialData = useMemo(

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -17,6 +17,8 @@ import {
   DEACTIVATED,
 } from './constants';
 
+import NewRelicService from '../../data/services/NewRelicService';
+
 export const SubscriptionContext = createContext();
 export const SubscriptionConsumer = SubscriptionContext.Consumer;
 
@@ -40,7 +42,7 @@ export default function SubscriptionData({ children }) {
           setUsers(responses[2]);
         })
         // eslint-disable-next-line no-console
-        .catch(error => console.log(error));
+        .catch(error => NewRelicService.logAPIErrorResponse(error));
     },
     [],
   );
@@ -59,7 +61,7 @@ export default function SubscriptionData({ children }) {
             setDetails(response);
           })
           // eslint-disable-next-line no-console
-          .catch(error => console.log(error))
+          .catch(error => NewRelicService.logAPIErrorResponse(error))
       ),
       fetchSubscriptionUsers: (options = {}) => {
         const licenseStatusByTab = {
@@ -83,7 +85,7 @@ export default function SubscriptionData({ children }) {
               setUsers(responses[1]);
             })
             // eslint-disable-next-line no-console
-            .catch(error => console.log(error))
+            .catch(error => NewRelicService.logAPIErrorResponse(error))
         );
       },
     }),

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -8,12 +8,9 @@ import SubscriptionData, { SubscriptionConsumer } from './SubscriptionData';
 import SubscriptionDetails from './SubscriptionDetails';
 import LicenseAllocationNavigation from './LicenseAllocationNavigation';
 import TabContentTable from './TabContentTable';
-import RemindUserButton from './RemindUserButton';
 import StatusAlert from '../StatusAlert';
 
 import './styles/SubscriptionManagementPage.scss';
-import { TAB_PENDING_USERS } from './constants';
-import AddUsersButton from './AddUsersButton';
 import { configuration } from '../../config';
 
 const PAGE_TITLE = 'Subscription Management';
@@ -26,7 +23,7 @@ export default function SubscriptionManagementPage() {
     visible: false, alertType: '', message: '',
   });
 
-  const setSuccessStatus = (visible, message) => {
+  const setSuccessStatus = ({ visible, message = '' }) => {
     setStatus({
       visible,
       alertType: 'success',
@@ -35,15 +32,16 @@ export default function SubscriptionManagementPage() {
   };
 
   const renderStatusMessage = () => (
-    status && status.visible &&
+    status && status.visible && (
       <StatusAlert
         alertType={status.alertType}
         iconClassName={status.iconClassName || `fa ${status.alertType === 'success' ? 'fa-check' : 'fa-times-circle'}`}
         title={status.title}
         message={status.message}
-        onClose={() => setSuccessStatus(false, '')}
+        onClose={() => setSuccessStatus({ visible: false })}
         dismissible
       />
+    )
   );
 
   return (
@@ -69,12 +67,7 @@ export default function SubscriptionManagementPage() {
                   License Allocation
                 </h3>
                 <SubscriptionConsumer>
-                  {({
-                    details,
-                    fetchSubscriptionUsers,
-                    overview,
-                    activeTab,
-                  }) => (
+                  {({ details, fetchSubscriptionUsers }) => (
                     <React.Fragment>
                       <p className="lead">
                         {details.licenses.allocated}
@@ -92,20 +85,7 @@ export default function SubscriptionManagementPage() {
                           />
                         </div>
                         <div className="col-12 col-lg-6">
-                          {activeTab === TAB_PENDING_USERS ?
-                            <RemindUserButton
-                              pendingUsersCount={overview.assigned}
-                              isBulkRemind
-                              onSuccess={() => setSuccessStatus(true, 'Successfully sent reminder(s)')}
-                            /> :
-                            <AddUsersButton
-                              onSuccess={() => setStatus({
-                                visible: true,
-                                alertType: 'success',
-                                message: 'Successfully assigned license(s)',
-                              })}
-                            />
-                          }
+                          <AddUsersDropdown />
                         </div>
                       </div>
                     </React.Fragment>
@@ -118,7 +98,7 @@ export default function SubscriptionManagementPage() {
                 </div>
                 <div className="col-12 col-lg-9">
                   {renderStatusMessage()}
-                  <StatusContext.Provider value={setStatus}>
+                  <StatusContext.Provider value={{ setStatus, setSuccessStatus }}>
                     <TabContentTable />
                   </StatusContext.Provider>
                 </div>

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -6,6 +6,7 @@ import Hero from '../Hero';
 import SearchBar from '../SearchBar';
 import SubscriptionData, { SubscriptionConsumer } from './SubscriptionData';
 import SubscriptionDetails from './SubscriptionDetails';
+import AddUsersButton from './AddUsersButton';
 import LicenseAllocationNavigation from './LicenseAllocationNavigation';
 import TabContentTable from './TabContentTable';
 import StatusAlert from '../StatusAlert';
@@ -85,7 +86,7 @@ export default function SubscriptionManagementPage() {
                           />
                         </div>
                         <div className="col-12 col-lg-7">
-                          <AddUsersDropdown />
+                          <AddUsersButton />
                         </div>
                       </div>
                     </React.Fragment>

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -75,7 +75,7 @@ export default function SubscriptionManagementPage() {
                         {details.licenses.available} licenses allocated
                       </p>
                       <div className="my-3 row">
-                        <div className="col-12 col-lg-6 mb-3 mb-lg-0">
+                        <div className="col-12 col-lg-5 mb-3 mb-lg-0">
                           <SearchBar
                             placeholder="Search by email..."
                               // eslint-disable-next-line no-console
@@ -84,7 +84,7 @@ export default function SubscriptionManagementPage() {
                             onClear={() => fetchSubscriptionUsers()}
                           />
                         </div>
-                        <div className="col-12 col-lg-6">
+                        <div className="col-12 col-lg-7">
                           <AddUsersDropdown />
                         </div>
                       </div>

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -79,7 +79,7 @@ export default function SubscriptionManagementPage() {
                           <SearchBar
                             placeholder="Search by email..."
                               // eslint-disable-next-line no-console
-                            onSearch={query => fetchSubscriptionUsers({ searchQuery: query })}
+                            onSearch={searchQuery => fetchSubscriptionUsers({ searchQuery })}
                               // eslint-disable-next-line no-console
                             onClear={() => fetchSubscriptionUsers()}
                           />

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -41,15 +41,7 @@ export default function TabContentTable() {
   const { setSuccessStatus } = useContext(StatusContext);
 
   useEffect(() => {
-    const licenseStatusByTab = {
-      [TAB_LICENSED_USERS]: 'active',
-      [TAB_PENDING_USERS]: 'assigned',
-      [TAB_DEACTIVATED_USERS]: 'deactivated',
-    };
-    fetchSubscriptionUsers({
-      statusFilter: licenseStatusByTab[activeTab],
-      searchQuery,
-    });
+    fetchSubscriptionUsers({ searchQuery });
   }, [activeTab]);
 
   const activeTabData = useMemo(
@@ -131,7 +123,7 @@ export default function TabContentTable() {
         </React.Fragment>
       ) : (
         <React.Fragment>
-          <hr />
+          <hr className="mt-0" />
           <StatusAlert
             alertType="warning"
             dialog={activeTabData.noResultsLabel}

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -4,6 +4,8 @@ import { Pagination, StatusAlert, Table } from '@edx/paragon';
 import LicenseStatus from './LicenseStatus';
 import LicenseActions from './LicenseActions';
 import { SubscriptionContext } from './SubscriptionData';
+import RemindUsersButton from './RemindUsersButton';
+import { StatusContext } from './SubscriptionManagementPage';
 
 import {
   TAB_ALL_USERS,
@@ -30,8 +32,13 @@ const columns = [
 
 export default function TabContentTable() {
   const {
-    activeTab, users, searchQuery, fetchSubscriptionUsers,
+    activeTab,
+    users,
+    searchQuery,
+    fetchSubscriptionUsers,
+    overview,
   } = useContext(SubscriptionContext);
+  const { setSuccessStatus } = useContext(StatusContext);
 
   useEffect(() => {
     const licenseStatusByTab = {
@@ -90,7 +97,19 @@ export default function TabContentTable() {
 
   return (
     <React.Fragment>
-      <h3 className="h4 mb-3">{activeTabData.title}</h3>
+      <div className="d-flex align-items-center justify-content-between">
+        <h3 className="h4 mb-3">{activeTabData.title}</h3>
+        {activeTab === TAB_PENDING_USERS && tableData.length > 0 && (
+          <RemindUsersButton
+            pendingUsersCount={overview.assigned}
+            isBulkRemind
+            onSuccess={() => setSuccessStatus({
+              visible: true,
+              message: 'Successfully sent reminder(s)',
+            })}
+          />
+        )}
+      </div>
       {tableData.length > 0 ? (
         <React.Fragment>
           <div className="table-responsive">

--- a/src/components/subscriptions/constants.js
+++ b/src/components/subscriptions/constants.js
@@ -4,3 +4,7 @@ export const TAB_PENDING_USERS = 'TAB_PENDING_USERS';
 export const TAB_DEACTIVATED_USERS = 'TAB_DEACTIVATED_USERS';
 
 export const PAGE_SIZE = 10;
+
+export const ACTIVE = 'active';
+export const ASSIGNED = 'assigned';
+export const DEACTIVATED = 'deactivated';

--- a/src/components/subscriptions/data/service.js
+++ b/src/components/subscriptions/data/service.js
@@ -1,29 +1,66 @@
 import faker from 'faker';
 import moment from 'moment';
 
-import { PAGE_SIZE } from '../constants';
+import { PAGE_SIZE, ACTIVE, ASSIGNED, DEACTIVATED } from '../constants';
 
-function createUser(licenseStatus) {
+export function createSampleUser(licenseStatus) {
   return {
-    uuid: faker.random.uuid(),
+    userId: faker.random.uuid(),
     emailAddress: faker.internet.email(),
     licenseStatus,
   };
 }
 
 const users = [
-  [...Array(6)].map(() => createUser('active')),
-  [...Array(3)].map(() => createUser('assigned')),
-  [...Array(1)].map(() => createUser('deactivated')),
+  [...Array(6)].map(() => createSampleUser(ACTIVE)),
+  [...Array(3)].map(() => createSampleUser(ASSIGNED)),
+  [...Array(1)].map(() => createSampleUser(DEACTIVATED)),
 ].flat();
 
 const getUsersByStatus = ({ status, list }) => list.filter(user => user.licenseStatus === status);
 
 function getAllocatedLicensesCount() {
-  const licensedUsers = getUsersByStatus({ status: 'active', list: users });
-  const pendingUsers = getUsersByStatus({ status: 'assigned', list: users });
+  const licensedUsers = getUsersByStatus({ status: ACTIVE, list: users });
+  const pendingUsers = getUsersByStatus({ status: ASSIGNED, list: users });
   return licensedUsers.length + pendingUsers.length;
 }
+
+function createNewUser({ userId, emailAddress, licenseStatus = ASSIGNED }) {
+  const user = { userId, emailAddress, licenseStatus };
+  users.append(user);
+  return user;
+}
+
+function updateUserLicenseStatus({ userId, status }) {
+  const index = users.findIndex(item => item.userId === userId);
+
+  if (index !== -1) {
+    users[index] = {
+      ...users[index],
+      licenseStatus: status,
+    };
+
+    return users[index];
+  }
+
+  return null;
+}
+
+const purchaseDate = moment(faker.date.past());
+const startDate = moment(purchaseDate).add(15, 'days');
+const endDate = moment(startDate).add(6, 'months');
+const numLicensedPurchased = faker.random.number({ min: 300, max: 1000 });
+
+const getSubscriptionDetails = () => ({
+  uuid: faker.random.uuid(),
+  purchaseDate: purchaseDate.toISOString(),
+  startDate: startDate.toISOString(),
+  endDate: endDate.toISOString(),
+  licenses: {
+    allocated: getAllocatedLicensesCount(),
+    available: numLicensedPurchased,
+  },
+});
 
 /**
  * This function mocks out the response from a non-existant API endpoint. Once the endpoint
@@ -31,20 +68,9 @@ function getAllocatedLicensesCount() {
  * call to get this data.
  */
 export function fetchSubscriptionDetails() {
-  const purchaseDate = moment(faker.date.past());
-  const startDate = moment(purchaseDate).add(15, 'days');
-  const endDate = moment(startDate).add(6, 'months');
-
-  return Promise.resolve({
-    uuid: faker.random.uuid(),
-    purchaseDate: purchaseDate.toISOString(),
-    startDate: startDate.toISOString(),
-    endDate: endDate.toISOString(),
-    licenses: {
-      allocated: getAllocatedLicensesCount(),
-      available: faker.random.number({ min: 300, max: 1000 }),
-    },
-  });
+  const details = getSubscriptionDetails();
+  return Promise.resolve(details);
+  // return Promise.reject(new Error('Could not connect to the server'));
 }
 
 /**
@@ -67,7 +93,8 @@ export function fetchSubscriptionUsersOverview(options = {}) {
     deactivated: getUsersByStatus({ status: 'deactivated', list: userList }).length,
   };
 
-  return response;
+  return Promise.resolve(response);
+  // return Promise.reject(new Error('Could not connect to the server'));
 }
 
 /**
@@ -86,7 +113,6 @@ export function fetchSubscriptionUsers(options = {}) {
   if (searchQuery) {
     response.results = response.results.filter(user => user.emailAddress === searchQuery);
   }
-
   if (statusFilter) {
     response.results = response.results.filter(user => user.licenseStatus === statusFilter);
   }
@@ -94,7 +120,10 @@ export function fetchSubscriptionUsers(options = {}) {
   response.count = response.results.length;
   response.results = response.results.slice(0, PAGE_SIZE);
 
+  console.log('fetchSubscriptionUsers...', options, response);
+
   return Promise.resolve(response);
+  // return Promise.reject(new Error('Could not connect to the server'));
 }
 
 /**
@@ -122,6 +151,24 @@ export function addLicensesForUsers(payload) {
  * call to get this data.
  */
 export function sendLicenseRevoke(options = {}) {
-  return Promise.resolve(options);
+  const { userId } = options;
+
+  updateUserLicenseStatus({ userId, status: DEACTIVATED });
+
+  const updatedUser = users.find(item => item.userId === userId);
+  return Promise.resolve(updatedUser);
+  // return Promise.reject(new Error('Could not connect to the server'));
+}
+
+/**
+ * This function mocks out the response from a non-existant API endpoint. Once the endpoint
+ * exists, the contents of this function will use the `apiClient` to make an actual API
+ * call to get this data.
+ */
+export function addUsers(options = {}) {
+  const { users: newUsers } = options;
+  const created = newUsers.map(user => createNewUser(user));
+
+  return Promise.resolve(created);
   // return Promise.reject(new Error('Could not connect to the server'));
 }

--- a/src/components/subscriptions/data/service.js
+++ b/src/components/subscriptions/data/service.js
@@ -120,8 +120,6 @@ export function fetchSubscriptionUsers(options = {}) {
   response.count = response.results.length;
   response.results = response.results.slice(0, PAGE_SIZE);
 
-  console.log('fetchSubscriptionUsers...', options, response);
-
   return Promise.resolve(response);
   // return Promise.reject(new Error('Could not connect to the server'));
 }

--- a/src/containers/LicenseRemindModal/LicenseRemindModal.test.jsx
+++ b/src/containers/LicenseRemindModal/LicenseRemindModal.test.jsx
@@ -55,11 +55,9 @@ describe('LicenseRemindModalWrapper', () => {
     const wrapper = mount(<LicenseRemindModalWrapper
       user={user}
       title="Remind"
-      subtitle="subtitle"
       isBulkRemind={false}
     />);
     expect(wrapper.find('.modal-title span').text()).toEqual('Remind');
-    expect(wrapper.find('.modal-title small').text()).toEqual('subtitle');
 
     expect(wrapper.find('.assignment-details p.bulk-selected-codes').text()).toEqual(`Email: ${user.emailAddress}`);
   });

--- a/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
+++ b/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
@@ -51,7 +51,7 @@ describe('LicenseRevokeModalWrapper', () => {
     spy = jest.spyOn(licenseService, 'sendLicenseRevoke');
 
     const wrapper = mount(<LicenseRevokeModalWrapper user={user} />);
-    expect(wrapper.find('.modal-title small').text()).toEqual(' Are you sure you want to revoke access?');
+    expect(wrapper.find('.modal-title small').text()).toEqual('Are you sure you want to revoke access?');
 
     expect(wrapper.find('.license-details p.message').text()).toEqual(`Revoking a license will remove access to the subscription catalog for ${user.emailAddress}. To re-enable access, you can assign this user to another license.`);
 

--- a/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
+++ b/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
@@ -12,7 +12,7 @@ import LicenseRevokeModal from './index';
 const mockStore = configureMockStore([thunk]);
 
 const user = {
-  uuid: 'ABC101',
+  userId: 'ABC101',
   emailAddress: 'edx@example.com',
   licenseStatus: 'active',
 };
@@ -24,6 +24,9 @@ const LicenseRevokeModalWrapper = props => (
         user={user}
         onClose={() => {}}
         onSuccess={() => {}}
+        setActiveTab={() => {}}
+        fetchSubscriptionDetails={() => {}}
+        fetchSubscriptionUsers={() => {}}
         {...props}
       />
     </Provider>

--- a/src/data/actions/licenseRevoke.js
+++ b/src/data/actions/licenseRevoke.js
@@ -26,20 +26,22 @@ const sendLicenseRevokeFailure = error => ({
 });
 
 const sendLicenseRevoke = ({
-  payload,
+  options,
   onSuccess = () => {},
   onError = () => {},
 }) => (
   (dispatch) => {
     dispatch(sendLicenseRevokeRequest());
-    return sendLicenseRevokeEndpoint(payload).then((response) => {
-      dispatch(sendLicenseRevokeSuccess(response));
-      onSuccess(response);
-    }).catch((error) => {
-      NewRelicService.logAPIErrorResponse(error);
-      dispatch(sendLicenseRevokeFailure(error));
-      onError(error);
-    });
+    return sendLicenseRevokeEndpoint(options)
+      .then((response) => {
+        dispatch(sendLicenseRevokeSuccess(response));
+        onSuccess(response);
+      })
+      .catch((error) => {
+        NewRelicService.logAPIErrorResponse(error);
+        dispatch(sendLicenseRevokeFailure(error));
+        onError(error);
+      });
   }
 );
 


### PR DESCRIPTION
Always show the "Add Users" button and conditionally render the "Remind all" button for just the "Pending Users" tab. Also, adds a count to the "Remind all" button:

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/2828721/84070609-6bfcaa80-a99a-11ea-9dd0-57dcc8c1a697.png">

More importantly (and what adds most of the complexity of this PR), using the fake data available on the page, the "Revoke" action for a user now changes the status of their license from activated/assigned to deactivated.

Then, we make (mocked) API calls to refresh the data for the page now that an action was performed to remove a user:
1. Upon successful revocation, we re-fetch the `SubscriptionPlan` details to get the new number of licenses allotted. This allow us to update the "X of Y licenses allotted" message.
1. We also need to re-fetch the [`overview` endpoint](https://github.com/edx/frontend-app-admin-portal/blob/master/src/components/subscriptions/data/service.js#L63) to update the counts in the tab navigation in the left sidebar, e.g. "Licensed Users (284)".
1. Finally, we need to re-fetch the current tab filter's table data to ensure that record is properly moved to a deactivated status from its previous status.

## Demo

![revoke_demo](https://user-images.githubusercontent.com/2828721/84000592-ef82b100-a932-11ea-8c70-f96f38ed936a.gif)



**Tests coming soon.**