### PR TITLE
Always generate route to support form

### DIFF
--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -167,16 +167,14 @@ class EnterpriseApp extends React.Component {
                       }
                     />
                   }
-                  {features.SUPPORT &&
-                    <Route
-                      key="support"
-                      exact
-                      path={`${baseUrl}/admin/support`}
-                      render={routeProps =>
-                        <SupportPage {...routeProps} />
-                      }
-                    />
-                  }
+                  <Route
+                    key="support"
+                    exact
+                    path={`${baseUrl}/admin/support`}
+                    render={routeProps =>
+                      <SupportPage {...routeProps} />
+                    }
+                  />
                   <Route path="" component={NotFoundPage} />
                 </Switch>
               </div>


### PR DESCRIPTION
* If an enterprise is logged into the portal, users can access the support page at 'admin/support'
* Without the flag enabled, the support page shows the old page (MailtoLink instead of a form)

ENT-2732