### PR TITLE
ENT-2955-Admin Dash: Connect revoke endpoint for subscriptions frontend

### DIFF
--- a/src/components/LicenseRevokeModal/index.jsx
+++ b/src/components/LicenseRevokeModal/index.jsx
@@ -52,10 +52,11 @@ class LicenseRevokeModal extends React.Component {
       fetchSubscriptionDetails,
       fetchSubscriptionUsers,
       searchQuery,
+      subscriptionUUID,
     } = this.props;
-    const options = { userId: user.userId };
+    const options = { user_email: user.userEmail };
 
-    return sendLicenseRevoke(options)
+    return sendLicenseRevoke(subscriptionUUID, options)
       .then(async (response) => {
         try {
           await fetchSubscriptionDetails();
@@ -85,7 +86,7 @@ class LicenseRevokeModal extends React.Component {
         <div className="license-details mb-4">
           <React.Fragment>
             <p className="message" >Revoking a license will remove access to the subscription catalog
-              for {user.emailAddress}. To re-enable access, you can assign this user to another
+              for {user.userEmail}. To re-enable access, you can assign this user to another
               license.
             </p>
           </React.Fragment>
@@ -178,13 +179,12 @@ LicenseRevokeModal.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   sendLicenseRevoke: PropTypes.func.isRequired,
   user: PropTypes.shape({
-    userId: PropTypes.string.isRequired,
-    emailAddress: PropTypes.string.isRequired,
-    licenseStatus: PropTypes.string.isRequired,
+    userEmail: PropTypes.string.isRequired,
   }).isRequired,
   fetchSubscriptionDetails: PropTypes.func.isRequired,
   fetchSubscriptionUsers: PropTypes.func.isRequired,
   searchQuery: PropTypes.string,
+  subscriptionUUID: PropTypes.string.isRequired,
 };
 
 export default reduxForm({

--- a/src/components/subscriptions/LicenseActions.jsx
+++ b/src/components/subscriptions/LicenseActions.jsx
@@ -19,6 +19,7 @@ export default function LicenseAction({ user }) {
     fetchSubscriptionUsers,
     searchQuery,
     activeTab,
+    details,
   } = useContext(SubscriptionContext);
 
   const licenseActions = useMemo(
@@ -39,6 +40,7 @@ export default function LicenseAction({ user }) {
                 fetchSubscriptionDetails={fetchSubscriptionDetails}
                 fetchSubscriptionUsers={fetchSubscriptionUsers}
                 searchQuery={searchQuery}
+                subscriptionUUID={details.uuid}
               />
             ),
           }];
@@ -77,6 +79,7 @@ export default function LicenseAction({ user }) {
                 fetchSubscriptionDetails={fetchSubscriptionDetails}
                 fetchSubscriptionUsers={fetchSubscriptionUsers}
                 searchQuery={searchQuery}
+                subscriptionUUID={details.uuid}
               />
             ),
           }];

--- a/src/components/subscriptions/data/service.js
+++ b/src/components/subscriptions/data/service.js
@@ -85,10 +85,10 @@ export function sendLicenseRevoke(options = {}) {
 }
 
 class LicenseManagerApiService {
-  static licenseManagerBaseUrl = `${configuration.LICENSE_MANAGER_BASE_URL}/api/v1/`;
+  static licenseManagerBaseUrl = `${configuration.LICENSE_MANAGER_BASE_URL}/api/v1`;
 
   static licenseAssign(options, subscriptionUUID) {
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses/assign/`;
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/assign/`;
     return apiClient.post(url, options, 'json');
   }
 
@@ -97,7 +97,7 @@ class LicenseManagerApiService {
       ...options,
     };
 
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/?${qs.stringify(queryParams)}`;
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/?${qs.stringify(queryParams)}`;
     return apiClient.get(url);
   }
 
@@ -106,7 +106,7 @@ class LicenseManagerApiService {
       ...options,
     };
 
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses/?${qs.stringify(queryParams)}`;
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/?${qs.stringify(queryParams)}`;
     return apiClient.get(url);
   }
 
@@ -115,8 +115,13 @@ class LicenseManagerApiService {
       ...options,
     };
 
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses/overview/?${qs.stringify(queryParams)}`;
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/overview/?${qs.stringify(queryParams)}`;
     return apiClient.get(url);
+  }
+
+  static licenseRevoke(subscriptionUUID, options) {
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/revoke/`;
+    return apiClient.post(url, options, 'json');
   }
 }
 

--- a/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
+++ b/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
@@ -6,16 +6,17 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
 
-import * as licenseService from '../../components/subscriptions/data/service';
+import LicenseManagerApiService from '../../components/subscriptions/data/service';
 import LicenseRevokeModal from './index';
 
 const mockStore = configureMockStore([thunk]);
 
 const user = {
   userId: 'ABC101',
-  emailAddress: 'edx@example.com',
+  userEmail: 'edx@example.com',
   licenseStatus: 'active',
 };
+const subscriptionUUID = '2e0caa85-3461-46b9-8c90-84681f43ba7c';
 
 const LicenseRevokeModalWrapper = props => (
   <MemoryRouter>
@@ -27,6 +28,7 @@ const LicenseRevokeModalWrapper = props => (
         setActiveTab={() => {}}
         fetchSubscriptionDetails={() => {}}
         fetchSubscriptionUsers={() => {}}
+        subscriptionUUID={subscriptionUUID}
         {...props}
       />
     </Provider>
@@ -51,12 +53,12 @@ describe('LicenseRevokeModalWrapper', () => {
   });
 
   it('renders license revoke modal', () => {
-    spy = jest.spyOn(licenseService, 'sendLicenseRevoke');
+    spy = jest.spyOn(LicenseManagerApiService, 'licenseRevoke');
 
     const wrapper = mount(<LicenseRevokeModalWrapper user={user} />);
     expect(wrapper.find('.modal-title small').text()).toEqual('Are you sure you want to revoke access?');
 
-    expect(wrapper.find('.license-details p.message').text()).toEqual(`Revoking a license will remove access to the subscription catalog for ${user.emailAddress}. To re-enable access, you can assign this user to another license.`);
+    expect(wrapper.find('.license-details p.message').text()).toEqual(`Revoking a license will remove access to the subscription catalog for ${user.userEmail}. To re-enable access, you can assign this user to another license.`);
 
     wrapper.find('.modal-footer .license-revoke-save-btn .btn-primary').hostNodes().simulate('click');
     expect(spy).toHaveBeenCalled();

--- a/src/containers/LicenseRevokeModal/index.jsx
+++ b/src/containers/LicenseRevokeModal/index.jsx
@@ -4,8 +4,9 @@ import LicenseRevokeModal from '../../components/LicenseRevokeModal';
 import sendLicenseRevoke from '../../data/actions/licenseRevoke';
 
 const mapDispatchToProps = dispatch => ({
-  sendLicenseRevoke: options => new Promise((resolve, reject) => {
+  sendLicenseRevoke: (subscriptionUUID, options) => new Promise((resolve, reject) => {
     dispatch(sendLicenseRevoke({
+      subscriptionUUID,
       options,
       onSuccess: (response) => { resolve(response); },
       onError: (error) => { reject(error); },

--- a/src/data/actions/licenseRevoke.js
+++ b/src/data/actions/licenseRevoke.js
@@ -4,7 +4,7 @@ import {
   LICENSE_REVOKE_FAILURE,
 } from '../constants/licenseRevoke';
 
-import { sendLicenseRevoke as sendLicenseRevokeEndpoint } from '../../components/subscriptions/data/service';
+import LicenseManagerApiService from '../../components/subscriptions/data/service';
 import NewRelicService from '../services/NewRelicService';
 
 const sendLicenseRevokeRequest = () => ({
@@ -26,13 +26,14 @@ const sendLicenseRevokeFailure = error => ({
 });
 
 const sendLicenseRevoke = ({
+  subscriptionUUID,
   options,
   onSuccess = () => {},
   onError = () => {},
 }) => (
   (dispatch) => {
     dispatch(sendLicenseRevokeRequest());
-    return sendLicenseRevokeEndpoint(options)
+    return LicenseManagerApiService.licenseRevoke(subscriptionUUID, options)
       .then((response) => {
         dispatch(sendLicenseRevokeSuccess(response));
         onSuccess(response);


### PR DESCRIPTION
When revoking licenses in the admin dash subscriptions page, the expected data is sent to the license manager service via API call.

Verify that the “Revoke” submit button in the modal has a spinner while the API call is pending, and the modal closes after successful revoke.

Verify that when the revoke endpoint errors, an error alert is shown in the “Revoke” modal.