### PR TITLE
ENT-2954: Connect remind endpoint for subscriptions frontend

### DIFF
--- a/src/components/subscriptions/LicenseActions.jsx
+++ b/src/components/subscriptions/LicenseActions.jsx
@@ -19,6 +19,7 @@ export default function LicenseAction({ user }) {
     fetchSubscriptionUsers,
     searchQuery,
     activeTab,
+    details,
   } = useContext(SubscriptionContext);
 
   const licenseActions = useMemo(
@@ -51,6 +52,8 @@ export default function LicenseAction({ user }) {
                 user={user}
                 isBulkRemind={false}
                 title="Remind User"
+                searchQuery={searchQuery}
+                subscriptionUUID={details.uuid}
                 onSuccess={() => setSuccessStatus({
                   visible: true,
                   message: 'Successfully sent reminder(s)',
@@ -60,7 +63,6 @@ export default function LicenseAction({ user }) {
                 }}
                 fetchSubscriptionDetails={fetchSubscriptionDetails}
                 fetchSubscriptionUsers={fetchSubscriptionUsers}
-                searchQuery={searchQuery}
               />
             ),
           }, {

--- a/src/components/subscriptions/LicenseStatus.jsx
+++ b/src/components/subscriptions/LicenseStatus.jsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import moment from 'moment';
+
 export default function LicenseStatus({ user }) {
   const licenseStatus = useMemo(
     () => {
@@ -13,11 +15,10 @@ export default function LicenseStatus({ user }) {
           };
         case 'assigned':
           return {
-            iconClassName: 'fa-hourglass-half text-muted',
             text: (
               <React.Fragment>
                 <span>Pending</span>
-                <span className="d-block text-muted">Since {user.pendingSince.format('MMMM DD, YYYY')}</span>
+                <span className="d-block text-muted">Since {moment(user.last_remind_date).format('MMMM DD, YYYY')}</span>
               </React.Fragment>
             ),
           };
@@ -48,6 +49,6 @@ export default function LicenseStatus({ user }) {
 LicenseStatus.propTypes = {
   user: PropTypes.shape({
     licenseStatus: PropTypes.string.isRequired,
-    pendingSince: PropTypes.object,
+    last_remind_date: PropTypes.object,
   }).isRequired,
 };

--- a/src/components/subscriptions/RemindUsersButton.jsx
+++ b/src/components/subscriptions/RemindUsersButton.jsx
@@ -9,6 +9,7 @@ const RemindUsersButton = ({
   onClose,
   pendingUsersCount,
   isBulkRemind,
+  subscriptionUUID,
   fetchSubscriptionDetails,
   fetchSubscriptionUsers,
   searchQuery,
@@ -26,29 +27,32 @@ const RemindUsersButton = ({
         pendingUsersCount={pendingUsersCount}
         isBulkRemind={isBulkRemind}
         title="Remind Users"
-        onSuccess={onSuccess}
+        subscriptionUUID={subscriptionUUID}
+        searchQuery={searchQuery}
         fetchSubscriptionDetails={fetchSubscriptionDetails}
         fetchSubscriptionUsers={fetchSubscriptionUsers}
-        searchQuery={searchQuery}
+        onSuccess={onSuccess}
         onClose={() => {
           closeModal();
           if (onClose) {
             onClose();
           }
         }}
+
       />
     )}
   />
 );
 
 RemindUsersButton.propTypes = {
-  onSuccess: PropTypes.func.isRequired,
   pendingUsersCount: PropTypes.number,
   isBulkRemind: PropTypes.bool.isRequired,
+  searchQuery: PropTypes.string,
+  subscriptionUUID: PropTypes.string.isRequired,
+  onSuccess: PropTypes.func.isRequired,
   onClose: PropTypes.func,
   fetchSubscriptionDetails: PropTypes.func.isRequired,
   fetchSubscriptionUsers: PropTypes.func.isRequired,
-  searchQuery: PropTypes.string,
 };
 
 RemindUsersButton.defaultProps = {

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -35,9 +35,10 @@ export default function TabContentTable() {
     activeTab,
     users,
     searchQuery,
+    overview,
+    details,
     fetchSubscriptionUsers,
     fetchSubscriptionDetails,
-    overview,
   } = useContext(SubscriptionContext);
   const { setSuccessStatus } = useContext(StatusContext);
 
@@ -80,8 +81,8 @@ export default function TabContentTable() {
   );
 
   const tableData = useMemo(
-    () => users.results.map(user => ({
-      emailAddress: user.emailAddress,
+    () => users?.results?.map(user => ({
+      emailAddress: user.user_email,
       status: <LicenseStatus user={user} />,
       actions: <LicenseActions user={user} />,
     })),
@@ -92,7 +93,7 @@ export default function TabContentTable() {
     <React.Fragment>
       <div className="d-flex align-items-center justify-content-between">
         <h3 className="h4 mb-3">{activeTabData.title}</h3>
-        {activeTab === TAB_PENDING_USERS && tableData.length > 0 && (
+        {activeTab === TAB_PENDING_USERS && tableData?.length > 0 && (
           <RemindUsersButton
             pendingUsersCount={overview.assigned}
             isBulkRemind
@@ -103,10 +104,11 @@ export default function TabContentTable() {
             fetchSubscriptionDetails={fetchSubscriptionDetails}
             fetchSubscriptionUsers={fetchSubscriptionUsers}
             searchQuery={searchQuery}
+            subscriptionUUID={details.uuid}
           />
         )}
       </div>
-      {tableData.length > 0 ? (
+      {tableData?.length > 0 ? (
         <React.Fragment>
           <div className="table-responsive">
             <Table

--- a/src/containers/LicenseRemindModal/index.jsx
+++ b/src/containers/LicenseRemindModal/index.jsx
@@ -4,9 +4,11 @@ import LicenseRemindModal from '../../components/LicenseRemindModal';
 import sendLicenseReminder from '../../data/actions/LicenseReminder';
 
 const mapDispatchToProps = dispatch => ({
-  sendLicenseReminder: options => new Promise((resolve, reject) => {
+  sendLicenseReminder: (options, subscriptionUUID, bulkRemind) => new Promise((resolve, reject) => {
     dispatch(sendLicenseReminder({
       options,
+      subscriptionUUID,
+      bulkRemind,
       onSuccess: (response) => { resolve(response); },
       onError: (error) => { reject(error); },
     }));

--- a/src/data/actions/LicenseReminder.js
+++ b/src/data/actions/LicenseReminder.js
@@ -4,7 +4,7 @@ import {
   LICENSE_REMIND_FAILURE,
 } from '../constants/licenseReminder';
 
-import { sendLicenseReminder as sendLicenseReminderEndpoint } from '../../components/subscriptions/data/service';
+import LicenseManagerApiService from '../services/LicenseManagerApiService';
 import NewRelicService from '../services/NewRelicService';
 
 const sendLicenseReminderRequest = () => ({
@@ -27,19 +27,22 @@ const sendLicenseReminderFailure = error => ({
 
 const sendLicenseReminder = ({
   options,
+  subscriptionUUID,
+  bulkRemind,
   onSuccess = () => {},
   onError = () => {},
 }) => (
   (dispatch) => {
     dispatch(sendLicenseReminderRequest());
-    return sendLicenseReminderEndpoint(options).then((response) => {
-      dispatch(sendLicenseReminderSuccess(response));
-      onSuccess(response);
-    }).catch((error) => {
-      NewRelicService.logAPIErrorResponse(error);
-      dispatch(sendLicenseReminderFailure(error));
-      onError(error);
-    });
+    return LicenseManagerApiService.licenseRemind(options, subscriptionUUID, bulkRemind)
+      .then((response) => {
+        dispatch(sendLicenseReminderSuccess(response));
+        onSuccess(response);
+      }).catch((error) => {
+        NewRelicService.logAPIErrorResponse(error);
+        dispatch(sendLicenseReminderFailure(error));
+        onError(error);
+      });
   }
 );
 

--- a/src/data/services/LicenseManagerApiService.js
+++ b/src/data/services/LicenseManagerApiService.js
@@ -1,0 +1,44 @@
+import qs from 'query-string';
+
+import apiClient from '../apiClient';
+import { configuration } from '../../config';
+
+class LicenseManagerApiService {
+  static licenseManagerBaseUrl = `${configuration.LICENSE_MANAGER_BASE_URL}/api/v1/`;
+
+  static fetchSubscriptions(options) {
+    const queryParams = {
+      ...options,
+    };
+
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/?${qs.stringify(queryParams)}`;
+    return apiClient.get(url);
+  }
+
+  static fetchSubscriptionUsers(subscriptionUUID, options) {
+    const queryParams = {
+      ...options,
+    };
+
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses?${qs.stringify(queryParams)}`;
+    return apiClient.get(url);
+  }
+
+  static fetchSubscriptionUsersOverview(subscriptionUUID, options) {
+    const queryParams = {
+      ...options,
+    };
+
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses/overview?${qs.stringify(queryParams)}`;
+    return apiClient.get(url);
+  }
+
+  static licenseRemind(options, subscriptionUUID, bulkRemind) {
+    const remindUrl = bulkRemind ? 'remind-all' : 'remind';
+
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}subscriptions/${subscriptionUUID}/licenses/${remindUrl}/`;
+    return apiClient.post(url, options, 'json');
+  }
+}
+
+export default LicenseManagerApiService;


### PR DESCRIPTION
- When reminding users in the admin dash subscriptions page, the expected data is sent to the license manager service via API call.
- The “Remind” submit button in the modal has a spinner while the API call is pending, and the modal closes after successful reminder (logic should already be in place, just need to verify).
- The “remind” endpoint errors, an error alert is shown in the “Remind” modal (logic should already be in place, just need to verify).

