### PR TITLE
ENT-2954: Connect remind endpoint for subscriptions frontend

### DIFF
--- a/src/components/LicenseRemindModal/index.jsx
+++ b/src/components/LicenseRemindModal/index.jsx
@@ -78,38 +78,31 @@ class LicenseRemindModal extends React.Component {
     const {
       isBulkRemind,
       user,
+      subscriptionUUID,
+      searchQuery,
       sendLicenseReminder,
       fetchSubscriptionDetails,
       fetchSubscriptionUsers,
-      searchQuery,
     } = this.props;
     // Validate form data
     this.validateFormData(formData);
     // Configure the options to send to the assignment reminder API endpoint
     const options = {
-      template: formData['email-template-body'],
-      template_greeting: formData['email-template-greeting'],
-      template_closing: formData['email-template-closing'],
+      greeting: formData['email-template-greeting'],
+      closing: formData['email-template-closing'],
     };
 
-    if (isBulkRemind) {
-      options.bulkRemind = true;
-    } else if (!isBulkRemind && user) {
-      options.email = user.emailAddress;
-      options.userId = user.userId;
+    if (!isBulkRemind && user) {
+      options.user_email = user.userEmail;
     }
-
-    return sendLicenseReminder(options)
+    return sendLicenseReminder(options, subscriptionUUID, isBulkRemind)
       .then(async (response) => {
-        try {
-          await fetchSubscriptionDetails();
-          await fetchSubscriptionUsers({ searchQuery });
-          this.props.onSuccess(response);
-        } catch (error) {
-          NewRelicService.logAPIErrorResponse(error);
-        }
+        await fetchSubscriptionUsers({ searchQuery });
+        await fetchSubscriptionDetails();
+        this.props.onSuccess(response);
       })
       .catch((error) => {
+        NewRelicService.logAPIErrorResponse(error);
         throw new SubmissionError({
           _error: [error.message],
         });
@@ -133,7 +126,7 @@ class LicenseRemindModal extends React.Component {
             {isBulkRemind ? (
               <p className="bulk-selected-codes">Unredeemed Licenses: {pendingUsersCount}</p>
             ) : (
-              <p className="bulk-selected-codes">Email: {user.emailAddress}</p>
+              <p className="bulk-selected-codes">Email: {user.userEmail}</p>
             )}
           </React.Fragment>
         </div>
@@ -259,12 +252,12 @@ LicenseRemindModal.propTypes = {
   isBulkRemind: PropTypes.bool,
   pendingUsersCount: PropTypes.number,
   user: PropTypes.shape({
-    userId: PropTypes.string,
-    emailAddress: PropTypes.string,
+    userEmail: PropTypes.string,
   }),
   fetchSubscriptionDetails: PropTypes.func.isRequired,
   fetchSubscriptionUsers: PropTypes.func.isRequired,
   searchQuery: PropTypes.string,
+  subscriptionUUID: PropTypes.string.isRequired,
 };
 export default reduxForm({
   form: 'license-reminder-modal-form',

--- a/src/components/subscriptions/LicenseActions.jsx
+++ b/src/components/subscriptions/LicenseActions.jsx
@@ -53,6 +53,8 @@ export default function LicenseAction({ user }) {
                 user={user}
                 isBulkRemind={false}
                 title="Remind User"
+                searchQuery={searchQuery}
+                subscriptionUUID={details.uuid}
                 onSuccess={() => setSuccessStatus({
                   visible: true,
                   message: 'Successfully sent reminder(s)',
@@ -62,7 +64,6 @@ export default function LicenseAction({ user }) {
                 }}
                 fetchSubscriptionDetails={fetchSubscriptionDetails}
                 fetchSubscriptionUsers={fetchSubscriptionUsers}
-                searchQuery={searchQuery}
               />
             ),
           }, {

--- a/src/components/subscriptions/RemindUsersButton.jsx
+++ b/src/components/subscriptions/RemindUsersButton.jsx
@@ -9,6 +9,7 @@ const RemindUsersButton = ({
   onClose,
   pendingUsersCount,
   isBulkRemind,
+  subscriptionUUID,
   fetchSubscriptionDetails,
   fetchSubscriptionUsers,
   searchQuery,
@@ -26,10 +27,11 @@ const RemindUsersButton = ({
         pendingUsersCount={pendingUsersCount}
         isBulkRemind={isBulkRemind}
         title="Remind Users"
-        onSuccess={onSuccess}
+        subscriptionUUID={subscriptionUUID}
+        searchQuery={searchQuery}
         fetchSubscriptionDetails={fetchSubscriptionDetails}
         fetchSubscriptionUsers={fetchSubscriptionUsers}
-        searchQuery={searchQuery}
+        onSuccess={onSuccess}
         onClose={() => {
           closeModal();
           if (onClose) {
@@ -42,13 +44,14 @@ const RemindUsersButton = ({
 );
 
 RemindUsersButton.propTypes = {
-  onSuccess: PropTypes.func.isRequired,
   pendingUsersCount: PropTypes.number,
   isBulkRemind: PropTypes.bool.isRequired,
+  searchQuery: PropTypes.string,
+  subscriptionUUID: PropTypes.string.isRequired,
+  onSuccess: PropTypes.func.isRequired,
   onClose: PropTypes.func,
   fetchSubscriptionDetails: PropTypes.func.isRequired,
   fetchSubscriptionUsers: PropTypes.func.isRequired,
-  searchQuery: PropTypes.string,
 };
 
 RemindUsersButton.defaultProps = {

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -37,6 +37,7 @@ export default function TabContentTable() {
     activeTab,
     users,
     searchQuery,
+    details,
     fetchSubscriptionUsers,
     fetchSubscriptionDetails,
     overview,
@@ -109,6 +110,7 @@ export default function TabContentTable() {
             fetchSubscriptionDetails={fetchSubscriptionDetails}
             fetchSubscriptionUsers={fetchSubscriptionUsers}
             searchQuery={searchQuery}
+            subscriptionUUID={details.uuid}
           />
         )}
       </div>

--- a/src/components/subscriptions/data/service.js
+++ b/src/components/subscriptions/data/service.js
@@ -92,6 +92,13 @@ class LicenseManagerApiService {
     return apiClient.post(url, options, 'json');
   }
 
+  static licenseRemind(options, subscriptionUUID, bulkRemind) {
+    const remindUrl = bulkRemind ? 'remind-all' : 'remind';
+
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/${remindUrl}/`;
+    return apiClient.post(url, options, 'json');
+  }
+
   static fetchSubscriptions(options) {
     const queryParams = {
       ...options,

--- a/src/containers/LicenseRemindModal/LicenseRemindModal.test.jsx
+++ b/src/containers/LicenseRemindModal/LicenseRemindModal.test.jsx
@@ -11,7 +11,7 @@ import LicenseRemindModal from './index';
 const mockStore = configureMockStore([thunk]);
 
 const user = {
-  emailAddress: 'edx@example.com',
+  userEmail: 'edx@example.com',
 };
 const pendingUsersCount = 5;
 
@@ -59,6 +59,6 @@ describe('LicenseRemindModalWrapper', () => {
     />);
     expect(wrapper.find('.modal-title span').text()).toEqual('Remind');
 
-    expect(wrapper.find('.assignment-details p.bulk-selected-codes').text()).toEqual(`Email: ${user.emailAddress}`);
+    expect(wrapper.find('.assignment-details p.bulk-selected-codes').text()).toEqual(`Email: ${user.userEmail}`);
   });
 });

--- a/src/containers/LicenseRemindModal/index.jsx
+++ b/src/containers/LicenseRemindModal/index.jsx
@@ -4,9 +4,11 @@ import LicenseRemindModal from '../../components/LicenseRemindModal';
 import sendLicenseReminder from '../../data/actions/LicenseReminder';
 
 const mapDispatchToProps = dispatch => ({
-  sendLicenseReminder: options => new Promise((resolve, reject) => {
+  sendLicenseReminder: (options, subscriptionUUID, bulkRemind) => new Promise((resolve, reject) => {
     dispatch(sendLicenseReminder({
       options,
+      subscriptionUUID,
+      bulkRemind,
       onSuccess: (response) => { resolve(response); },
       onError: (error) => { reject(error); },
     }));

--- a/src/data/actions/LicenseReminder.js
+++ b/src/data/actions/LicenseReminder.js
@@ -4,7 +4,7 @@ import {
   LICENSE_REMIND_FAILURE,
 } from '../constants/licenseReminder';
 
-import { sendLicenseReminder as sendLicenseReminderEndpoint } from '../../components/subscriptions/data/service';
+import LicenseManagerApiService from '../../components/subscriptions/data/service';
 import NewRelicService from '../services/NewRelicService';
 
 const sendLicenseReminderRequest = () => ({
@@ -27,19 +27,22 @@ const sendLicenseReminderFailure = error => ({
 
 const sendLicenseReminder = ({
   options,
+  subscriptionUUID,
+  bulkRemind,
   onSuccess = () => {},
   onError = () => {},
 }) => (
   (dispatch) => {
     dispatch(sendLicenseReminderRequest());
-    return sendLicenseReminderEndpoint(options).then((response) => {
-      dispatch(sendLicenseReminderSuccess(response));
-      onSuccess(response);
-    }).catch((error) => {
-      NewRelicService.logAPIErrorResponse(error);
-      dispatch(sendLicenseReminderFailure(error));
-      onError(error);
-    });
+    return LicenseManagerApiService.licenseRemind(options, subscriptionUUID, bulkRemind)
+      .then((response) => {
+        dispatch(sendLicenseReminderSuccess(response));
+        onSuccess(response);
+      }).catch((error) => {
+        NewRelicService.logAPIErrorResponse(error);
+        dispatch(sendLicenseReminderFailure(error));
+        onError(error);
+      });
   }
 );
 


### PR DESCRIPTION
- When reminding users in the admin dash subscriptions page, the expected data is sent to the license manager service via API call.
- The “Remind” submit button in the modal has a spinner while the API call is pending, and the modal closes after successful reminder (logic should already be in place, just need to verify).
- The “remind” endpoint errors, an error alert is shown in the “Remind” modal (logic should already be in place, just need to verify).