### PR TITLE
ENT-3166: Support form creates Zendesk ticket

### DIFF
--- a/src/components/SupportPage/SupportForm.jsx
+++ b/src/components/SupportPage/SupportForm.jsx
@@ -88,6 +88,19 @@ class SupportForm extends React.Component {
                 disabled
               />
               <Field
+                name="subject"
+                type="text"
+                component={RenderField}
+                label={
+                  <React.Fragment>
+                    Subject
+                    <span className="required">*</span>
+                  </React.Fragment>
+                }
+                validate={[isRequired]}
+                required
+              />
+              <Field
                 name="notes"
                 type="text"
                 component={TextAreaAutoSize}

--- a/src/components/SupportPage/SupportForm.jsx
+++ b/src/components/SupportPage/SupportForm.jsx
@@ -56,10 +56,10 @@ class SupportForm extends React.Component {
     return (
       <React.Fragment>
         {submitFailed && error && this.renderErrorMessage()}
-        {submitSucceeded && this.renderSuccessMessage()}
+        {submitSucceeded && this.renderSuccessMessage}
         <div className="support-form row">
           <div className="col-12 col-md-6 col-lg-4">
-            <form onSubmit={handleSubmit(this.renderSuccessMessage)}>
+            <form onSubmit={handleSubmit}>
               <Field
                 name="emailAddress"
                 type="email"
@@ -91,8 +91,14 @@ class SupportForm extends React.Component {
                 name="notes"
                 type="text"
                 component={TextAreaAutoSize}
-                label="Notes"
-                validate={[maxLength512]}
+                label={
+                  <React.Fragment>
+                    Notes
+                    <span className="required">*</span>
+                  </React.Fragment>
+                }
+                validate={[isRequired, maxLength512]}
+                required
               />
               <Button
                 type="submit"

--- a/src/components/SupportPage/SupportForm.jsx
+++ b/src/components/SupportPage/SupportForm.jsx
@@ -10,12 +10,6 @@ import TextAreaAutoSize from '../TextAreaAutoSize';
 import { isRequired, isValidEmail, maxLength512 } from '../../utils';
 
 class SupportForm extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.renderSuccessMessage = this.renderSuccessMessage.bind(this);
-  }
-
   renderErrorMessage() {
     const { error: { message } } = this.props;
 
@@ -56,7 +50,7 @@ class SupportForm extends React.Component {
     return (
       <React.Fragment>
         {submitFailed && error && this.renderErrorMessage()}
-        {submitSucceeded && this.renderSuccessMessage}
+        {submitSucceeded && this.renderSuccessMessage()}
         <div className="support-form row">
           <div className="col-12 col-md-6 col-lg-4">
             <form onSubmit={handleSubmit}>

--- a/src/components/SupportPage/index.jsx
+++ b/src/components/SupportPage/index.jsx
@@ -46,7 +46,7 @@ class SupportPage extends React.Component {
                       })
                   )}
                   initialValues={{
-                    emailAddress, enterpriseName, notes: '',
+                    emailAddress, enterpriseName, subject: '', notes: '',
                   }}
                   match={match}
                 />

--- a/src/components/SupportPage/index.jsx
+++ b/src/components/SupportPage/index.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
+import { SubmissionError } from 'redux-form';
 import { MailtoLink } from '@edx/paragon';
 
 import SupportForm from './SupportForm';
 import Hero from '../Hero';
 import { features } from '../../config/index';
+
+import ZendeskApiService from '../../data/services/ZendeskApiService';
+import NewRelicService from '../../data/services/NewRelicService';
 
 import './SupportPage.scss';
 
@@ -33,6 +37,14 @@ class SupportPage extends React.Component {
             <div className="col">
               {features.SUPPORT && this.hasEmailAndEnterpriseName() ? (
                 <SupportForm
+                  onSubmit={options => (
+                    ZendeskApiService.createZendeskTicket(options)
+                      .then(response => response)
+                      .catch((error) => {
+                        NewRelicService.logAPIErrorResponse(error);
+                        throw new SubmissionError({ _error: error });
+                      })
+                  )}
                   initialValues={{
                     emailAddress, enterpriseName, notes: '',
                   }}

--- a/src/data/services/ZendeskApiService.js
+++ b/src/data/services/ZendeskApiService.js
@@ -1,0 +1,25 @@
+import apiClient from '../apiClient';
+import { configuration } from '../../config';
+
+class ZendeskApiService {
+    static baseUrl = configuration.LMS_BASE_URL;
+    static createZendeskTicket(options) {
+      const url = `${ZendeskApiService.baseUrl}/zendesk_proxy/v1`;
+      const data = {
+        requester: {
+          email: options.emailAddress,
+          name: options.enterpriseName,
+        },
+        subject: 'Enterprise Admin Support',
+        comment: {
+          body: options.notes,
+          uploads: [],
+        },
+        custom_fields: [],
+        tags: ['enterprise_admin_support'],
+      };
+      return apiClient.post(url, data, 'json');
+    }
+}
+
+export default ZendeskApiService;

--- a/src/data/services/ZendeskApiService.js
+++ b/src/data/services/ZendeskApiService.js
@@ -1,25 +1,31 @@
 import apiClient from '../apiClient';
 import { configuration } from '../../config';
 
+
+ // API Service that creates a Zendesk ticket by making a call to the Zendesk API proxy located within edx-platform.
 class ZendeskApiService {
-    static baseUrl = configuration.LMS_BASE_URL;
-    static createZendeskTicket(options) {
-      const url = `${ZendeskApiService.baseUrl}/zendesk_proxy/v1`;
-      const data = {
-        requester: {
-          email: options.emailAddress,
-          name: options.enterpriseName,
-        },
-        subject: 'Enterprise Admin Support',
-        comment: {
-          body: options.notes,
-          uploads: [],
-        },
-        custom_fields: [],
-        tags: ['enterprise_admin_support'],
-      };
-      return apiClient.post(url, data, 'json');
-    }
+  /**
+   * A method to create a Zendesk ticket and make a post request to the Zendesk API proxy.
+   * The proxy will create the ticket with these parameters.
+   * @param options form data that is passed in
+   */
+  static createZendeskTicket(options) {
+    const url = `${configuration.LMS_BASE_URL}/zendesk_proxy/v1`;
+    const data = {
+      requester: {
+        email: options.emailAddress,
+        name: options.enterpriseName,
+      },
+      subject: options.subject,
+      comment: {
+        body: options.notes,
+        uploads: [],
+      },
+      custom_fields: [],
+      tags: ['enterprise_admin_support'],
+    };
+    return apiClient.post(url, data, 'json');
+  }
 }
 
 export default ZendeskApiService;

--- a/src/data/services/ZendeskApiService.js
+++ b/src/data/services/ZendeskApiService.js
@@ -1,11 +1,12 @@
 import apiClient from '../apiClient';
 import { configuration } from '../../config';
 
-
- // API Service that creates a Zendesk ticket by making a call to the Zendesk API proxy located within edx-platform.
+/**
+* API Service that makes a call to the Zendesk API proxy in edx-platform.
+*/
 class ZendeskApiService {
   /**
-   * A method to create a Zendesk ticket and make a post request to the Zendesk API proxy.
+   * Creates a Zendesk ticket and makes a post request to the Zendesk API proxy.
    * The proxy will create the ticket with these parameters.
    * @param options form data that is passed in
    */


### PR DESCRIPTION
## Description
Submitting the support form creates a post request to the Zendesk proxy that currently resides in edx-platform. This way, users can submit a request without exposing API secrets. The Zendesk proxy takes the fields that the user enters and creates a ticket.

- https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/zendesk_proxy


## Ticket Information
The ticket is created with the inputted form fields. The tag "enterprise_admin_support" is associated with a trigger within the Zendesk Help Desk so that any ticket with that tag is sent to the edX for Business brand. Currently, ECS processes tickets that are in the edX for Business brand in Zendesk.

## Testing Considerations
- Utilized the Zendesk sandbox workflow and observed that tickets created with the "enterprise_admin_support" tag get routed to a specific brand
- However, we want to test the creation of tickets within stage with the prod Zendesk API keys/configuration and also ask ECS if there are any additional parameters they want to be added to the tickets