### PR TITLE
ENT-3150:Fix UI/UX issues related to integration of subscriptions backend

### DIFF
--- a/src/components/subscriptions/LicenseAllocationNavigation.jsx
+++ b/src/components/subscriptions/LicenseAllocationNavigation.jsx
@@ -22,7 +22,7 @@ export default function LicenseAllocationNavigation() {
     () => [
       {
         key: TAB_ALL_USERS,
-        text: `All Users (${overview.all})`,
+        text: `All Users (${overview.assigned + overview.activated + overview.deactivated})`,
       },
       {
         key: TAB_LICENSED_USERS,

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -9,6 +9,7 @@ import {
   ACTIVATED,
   ASSIGNED,
   DEACTIVATED,
+  ALL_USERS,
 } from './constants';
 
 import { useSubscriptionData } from './hooks/licenseManagerHooks';
@@ -59,6 +60,7 @@ export default function SubscriptionData({ children, enterpriseId }) {
       fetchSubscriptionDetails: fetch,
       fetchSubscriptionUsers: (options = {}) => {
         const licenseStatusByTab = {
+          [TAB_ALL_USERS]: ALL_USERS,
           [TAB_LICENSED_USERS]: ACTIVATED,
           [TAB_PENDING_USERS]: ASSIGNED,
           [TAB_DEACTIVATED_USERS]: DEACTIVATED,

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -57,25 +57,25 @@ export default function TabContentTable() {
           return {
             title: 'All Users',
             paginationLabel: 'pagination for all users',
-            noResultsLabel: 'There are no users.',
+            noResultsLabel: 'There are no Pending, Activated or Deactivated users',
           };
         case TAB_PENDING_USERS:
           return {
             title: 'Pending Users',
             paginationLabel: 'pagination for pending users',
-            noResultsLabel: 'There are no pending users.',
+            noResultsLabel: 'There are no pending users',
           };
         case TAB_LICENSED_USERS:
           return {
             title: 'Licensed Users',
             paginationLabel: 'pagination for licensed users',
-            noResultsLabel: 'There are no licensed users.',
+            noResultsLabel: 'There are no licensed users',
           };
         case TAB_DEACTIVATED_USERS:
           return {
             title: 'Deactivated Users',
             paginationLabel: 'pagination for deactivated users',
-            noResultsLabel: 'There are no deactivated users.',
+            noResultsLabel: 'There are no deactivated users',
           };
         default:
           return null;
@@ -153,7 +153,8 @@ export default function TabContentTable() {
               <hr className="mt-0" />
               <StatusAlert
                 alertType="warning"
-                dialog={activeTabData.noResultsLabel}
+                title="No results found"
+                message={activeTabData.noResultsLabel}
                 dismissible={false}
                 open
               />

--- a/src/components/subscriptions/constants.js
+++ b/src/components/subscriptions/constants.js
@@ -8,6 +8,7 @@ export const PAGE_SIZE = 10;
 export const ACTIVATED = 'activated';
 export const ASSIGNED = 'assigned';
 export const DEACTIVATED = 'deactivated';
+export const ALL_USERS = 'assigned,activated,deactivated';
 
 export const SUBSCRIPTIONS = 'Subscriptions';
 export const SUBSCRIPTION_OVERVIEW = 'Subscription Overview';


### PR DESCRIPTION
**JIRA**: https://openedx.atlassian.net/browse/ENT-3150

**Issues Fixed:**

-  Assignments in the grid do not appear to be correct in ALL USERS TAB, it shows unassigned licenses

- The search results should gracefully handle the scenario if no results are found and display an appropriate message. Same goes for the all 4 filters at the left Licensed, Pending, Deactivated..etc.

- All Users count in LicenseAllocationNavigation should be equal to assigned+activated+deactivated licenses, currently it is showing total licenses

_Note: This PR requires backend changes made in this PR: https://github.com/edx/license-manager/pull/78_