### PR TITLE
ENT-3177 Show the error message only once the api call is completed.

### DIFF
--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -31,7 +31,7 @@ export default function SubscriptionData({ children, enterpriseId }) {
   const [currentPage, setCurrentPage] = useState(DEFAULT_PAGE);
 
   const {
-    fetch, isLoading, errors, data,
+    fetch, isLoading, errors, data, hasSubscription,
   } = useSubscriptionData({
     enterpriseId, search: searchQuery, status: filter, page: currentPage,
   });
@@ -98,10 +98,10 @@ export default function SubscriptionData({ children, enterpriseId }) {
   return (
     <StatusAlert
       className="mt-3"
-      alertType="danger"
-      message={`Your organization does not have any active subscriptions to manage.
+      alertType={hasSubscription === false ? 'danger' : ''}
+      message={hasSubscription === false ? `Your organization does not have any active subscriptions to manage.
       If you believe you are seeing this message in error,
-      please reach out to the edX Customer Success team at customersuccess@edx.org.`}
+      please reach out to the edX Customer Success team at customersuccess@edx.org.` : ''}
     />
   );
 }

--- a/src/components/subscriptions/hooks/licenseManagerHooks.js
+++ b/src/components/subscriptions/hooks/licenseManagerHooks.js
@@ -12,6 +12,7 @@ export const useSubscriptions = (enterpriseId) => {
     next: null,
     previous: null,
   });
+  const [hasSubscription, setHasSubscription] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -28,6 +29,7 @@ export const useSubscriptions = (enterpriseId) => {
         ) || [];
 
         setSubscriptions(subscriptionsData);
+        setHasSubscription(subscriptionsData?.results?.length > 0);
       })
       .catch((err) => {
         NewRelicService.logAPIErrorResponse(err);
@@ -37,7 +39,7 @@ export const useSubscriptions = (enterpriseId) => {
   };
 
   return {
-    fetch, subscriptions, isLoading, error,
+    fetch, subscriptions, isLoading, error, hasSubscription,
   };
 };
 
@@ -143,6 +145,7 @@ export const useSubscriptionData = ({
     subscriptions,
     isLoading: isLoadingSubscriptions,
     error: subscriptionsError,
+    hasSubscription,
   } = useSubscriptions(enterpriseId);
   const {
     fetch: fetchSubscriptionUsersOverview,
@@ -222,6 +225,6 @@ export const useSubscriptionData = ({
   ]);
 
   return {
-    fetch, isLoading, errors, data,
+    fetch, isLoading, errors, data, hasSubscription,
   };
 };


### PR DESCRIPTION
Admin Dash Subscriptions page briefly displays empty/error state before loading all the data