### PR TITLE
Add more filters to learners screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1438,9 +1438,9 @@
       "integrity": "sha512-IN0Bgh0/1Ax3TMPfZztqzdJchW4B5Px9PT4V9uu6TMj2Cj8el1CV3jrSA4Idg8C3CAkFZ/EHjmaFVCxgJ9aXVA=="
     },
     "@edx/paragon": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-9.0.1.tgz",
-      "integrity": "sha512-FeiyG8VZBueGGjrW+I2sgH/knmZVI9qGjl5e+xN5QhCLHOHQA81mpFmWYE+IoMvFJpOFCpHllSsIpviXmsnLPg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-9.1.0.tgz",
+      "integrity": "sha512-5ypyEaEsFrrL68nOaaJekiEGGspJQvNABK455Ys2tolNyFKPY5QUtxVH4pZIJ/7iuDyWcga7B1I1ejZI6yjMYQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.21",
         "@fortawesome/free-solid-svg-icons": "^5.10.1",
@@ -1452,6 +1452,7 @@
         "font-awesome": "^4.7.0",
         "mailto-link": "^1.0.0",
         "prop-types": "^15.7.2",
+        "react-bootstrap": "^1.2.2",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^6.1.1",
         "react-transition-group": "^4.0.0",
@@ -1523,30 +1524,30 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz",
-      "integrity": "sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg=="
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
+      "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz",
-      "integrity": "sha512-4LeaNHWvrneoU0i8b5RTOJHKx7E+y7jYejplR7uSVB34+mp3Veg7cbKk7NBCLiI4TyoWS1wh9ZdoyLJR8wSAdg==",
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz",
+      "integrity": "sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz",
+      "integrity": "sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz",
-      "integrity": "sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz",
+      "integrity": "sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==",
       "requires": {
         "prop-types": "^15.7.2"
       }
@@ -1567,10 +1568,29 @@
         "postcss": "^7.0.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+    },
     "@redux-beacon/segment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@redux-beacon/segment/-/segment-1.1.0.tgz",
       "integrity": "sha512-NLRoP3Jfx5z99YX6TFFznwXIMjqjD6/qdMZIKFRgGO8NtMWrCruA8EeQYPJZUBnuOjw6RtOA1UdjbqyRmdhc/Q=="
+    },
+    "@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+    },
+    "@restart/hooks": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.25.tgz",
+      "integrity": "sha512-m2v3N5pxTsIiSH74/sb1yW8D9RxkJidGW+5Mfwn/lHb2QzhZNlaU1su7abSyT9EGf0xS/0waLjrf7/XxQHUk7w==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      }
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -1583,6 +1603,11 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@types/classnames": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
+      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
     },
     "@types/cookie": {
       "version": "0.3.3",
@@ -1606,6 +1631,11 @@
         "@types/node": "*"
       }
     },
+    "@types/invariant": {
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.33.tgz",
+      "integrity": "sha512-/jUNmS8d4bCKdqslfxW6dg/9Gksfzxz67IYfqApHn+HvHlMVXwYv2zpTDnS/yaK9BB0i0GlBTaYci0EFE62Hmw=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1628,11 +1658,33 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
+      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/tapable": {
       "version": "0.2.5",
@@ -1648,6 +1700,11 @@
       "requires": {
         "source-map": "^0.6.1"
       }
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/webpack": {
       "version": "3.8.18",
@@ -3644,9 +3701,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
+      "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5904,9 +5961,9 @@
       }
     },
     "domutils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
-      "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
+      "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
       "requires": {
         "dom-serializer": "^0.2.1",
         "domelementtype": "^2.0.1",
@@ -11717,11 +11774,6 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
@@ -11733,11 +11785,6 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
       "dev": true
-    },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -11754,23 +11801,14 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -12645,43 +12683,6 @@
       "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
       "dev": true
     },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "dev": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12868,6 +12869,35 @@
             "number-is-nan": "^1.0.0"
           }
         },
+        "node-gyp": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+          "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+          "dev": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
         "npmlog": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -12879,6 +12909,12 @@
             "gauge": "~2.7.3",
             "set-blocking": "~2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -12896,6 +12932,17 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
         }
       }
     },
@@ -14520,6 +14567,15 @@
         "reflect.ownkeys": "^0.2.0"
       }
     },
+    "prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "requires": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -14769,6 +14825,31 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-bootstrap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.2.2.tgz",
+      "integrity": "sha512-G+QcEyBqFtakBNghdDugie+yU/ABDeqw3n+SOeRGxEn1m0dbIyHTroZpectcQk6FB3aS4RJGkZTuLVYH86Cu2A==",
+      "requires": {
+        "@babel/runtime": "^7.4.2",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.21",
+        "@types/classnames": "^2.2.10",
+        "@types/invariant": "^2.2.33",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^16.9.35",
+        "@types/react-transition-group": "^4.4.0",
+        "@types/warning": "^3.0.0",
+        "classnames": "^2.2.6",
+        "dom-helpers": "^5.1.2",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "prop-types-extra": "^1.1.0",
+        "react-overlays": "^4.0.0",
+        "react-transition-group": "^4.0.0",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-dev-utils": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
@@ -15011,6 +15092,21 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-overlays": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
+      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "@popperjs/core": "^2.0.0",
+        "@restart/hooks": "^0.3.12",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.1.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-proptype-conditional-require": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
@@ -15125,9 +15221,9 @@
       }
     },
     "react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -16431,20 +16527,14 @@
       }
     },
     "sanitize-html": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.23.0.tgz",
-      "integrity": "sha512-7MgUrbZpaig6zHwuHjpNqhkiuutFPWWoFY/RmdtEnvrFKMLafzSHfFyOozVpKWytkZIUhbYu3VQ/93OmYdo3ag==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.1.tgz",
+      "integrity": "sha512-C+N7E+7ikYaLHdb9lEkQaFOgmj+9ddZ311Ixs/QsBsoLD411/vdLweiFyGqrswUVgLqagOS5NCDxcEPH7trObQ==",
       "requires": {
-        "chalk": "^2.4.1",
         "htmlparser2": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.2",
+        "lodash": "^4.17.15",
         "postcss": "^7.0.27",
-        "srcset": "^2.0.1",
-        "xtend": "^4.0.1"
+        "srcset": "^2.0.1"
       }
     },
     "sass-graph": {
@@ -18074,17 +18164,6 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "dev": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
-    },
     "tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -18687,6 +18766,17 @@
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
+      }
+    },
+    "uncontrollable": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
+      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": "^16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -20464,7 +20554,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime-corejs3": "^7.9.6",
     "@edx/frontend-auth": "^5.3.6",
     "@edx/frontend-logging": "^2.1.0",
-    "@edx/paragon": "^9.0.1",
+    "@edx/paragon": "^9.1.0",
     "@fullstory/browser": "^1.4.4",
     "@redux-beacon/segment": "^1.1.0",
     "axios": "^0.18.1",

--- a/src/components/Admin/Admin.scss
+++ b/src/components/Admin/Admin.scss
@@ -6,3 +6,7 @@
 .reset {
     margin-top: -5px;
 }
+
+.search-label {
+    line-height: 1.5;
+}

--- a/src/components/Admin/AdminSearchForm.jsx
+++ b/src/components/Admin/AdminSearchForm.jsx
@@ -1,0 +1,163 @@
+/* eslint-disable camelcase */
+import qs from 'query-string';
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import { Form } from '@edx/paragon';
+
+import SearchBar from '../SearchBar';
+import { updateUrl } from '../../utils';
+
+class AdminSearchForm extends React.Component {
+  constructor(props) {
+    super(props);
+    const { location } = props;
+    const queryParams = qs.parse(location.search);
+    this.state = {
+      searchQuery: queryParams.search,
+      searchCourseQuery: queryParams.search_course,
+      searchDateQuery: queryParams.search_start_date,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { location } = this.props;
+    if (location.search !== prevProps.location.search) {
+      // eslint-disable-next-line camelcase
+      const { search, search_course, search_start_date } = qs.parse(location.search);
+      const {
+        search: prevSearch,
+        search_course: prevSearchCourse,
+        search_start_date: prevSearchDate,
+      } = qs.parse(prevProps.location.search);
+      if (search !== prevSearch || search_course !== prevSearchCourse ||
+        search_start_date !== prevSearchDate) {
+        this.handleSearch(search, search_course, search_start_date);
+      }
+    }
+  }
+
+  onCourseSelect(event) {
+    const updateParams = {
+      search_course: event.target.value,
+      page: 1,
+    };
+    if (event.target.value === '') {
+      updateParams.search_start_date = '';
+    }
+    updateUrl(updateParams);
+  }
+
+  handleSearch(emailSearch, courseSearch, dateSearch) {
+    this.setState({
+      searchQuery: emailSearch,
+      searchCourseQuery: courseSearch,
+      searchDateQuery: dateSearch,
+    });
+    this.props.searchEnrollmentsList();
+  }
+
+  render() {
+    const { searchCourseQuery, searchDateQuery, searchQuery } = this.state;
+    const { tableData } = this.props;
+    const courseTitles = new Set(tableData.map(en => en.course_title));
+    const courseDates = new Set(tableData.map(en => en.course_start).sort().reverse());
+
+    return (
+      <div className="row">
+        <div className="col-12 pr-md-0 mb-0">
+          <div className="row w-100 m-0">
+            <div className="col-12 col-md-6 px-0">
+              <Form inline role="search">
+                <div className="col-6 pl-0 pr-md-2 pr-lg-3">
+                  <Form.Group>
+                    <Form.Label id="course-title-search" className="search-label mb-2">Filter by course</Form.Label>
+                    <Form.Control
+                      className="w-100"
+                      as="select"
+                      aria-labelledby="course-title-search"
+                      value={searchCourseQuery}
+                      onChange={e => this.onCourseSelect(e)}
+                    >
+                      <option value="">All Courses</option>
+                      {courseTitles.map(title => (
+                        <option
+                          value={title}
+                          key={title}
+                        >
+                          {title}
+                        </option>))}
+                    </Form.Control>
+                  </Form.Group>
+                </div>
+                <div className="col-6 pr-0 px-md-2 px-lg-3">
+                  <Form.Group>
+                    <Form.Label id="date-search" className="search-label mb-2">Filter by start date</Form.Label>
+                    <Form.Control
+                      as="select"
+                      className="w-100"
+                      aria-labelledby="date-search"
+                      value={searchDateQuery}
+                      onChange={event => updateUrl({
+                        search_start_date: event.target.value,
+                        page: 1,
+                        })
+                    }
+                      disabled={!searchCourseQuery}
+                    >
+                      <option value="">{searchCourseQuery ? 'All Dates' : 'Choose a course'}</option>
+                      {searchCourseQuery && courseDates.map(date => (
+                        <option
+                          value={date}
+                          key={date}
+                        >
+                          {moment(date).format('MMMM D, YYYY')}
+                        </option>))}
+                    </Form.Control>
+                  </Form.Group>
+                </div>
+              </Form>
+            </div>
+            <div className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3">
+              <Form.Label id="search-email-label" className="mb-2">Filter by email</Form.Label>
+              <SearchBar
+                placeholder="Search by email..."
+                onSearch={query => updateUrl({
+                  search: query,
+                  page: 1,
+                })}
+                onClear={() => updateUrl({ search: undefined })}
+                value={searchQuery}
+                aria-labelledby="search-email-label"
+                className="py-0"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+AdminSearchForm.defaultProps = {
+  location: {
+    search: null,
+  },
+  tableData: [],
+};
+
+AdminSearchForm.propTypes = {
+  searchEnrollmentsList: PropTypes.func.isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }),
+  match: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    params: PropTypes.shape({
+      actionSlug: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+  tableData: PropTypes.arrayOf(PropTypes.shape({})),
+};
+
+export default AdminSearchForm;

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -612,19 +612,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -1171,19 +1171,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -1735,19 +1735,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -2281,25 +2281,114 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-8 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
+          >
+            <button
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              type="button"
+            >
+              <span
+                aria-hidden={true}
+                className="fa mr-2 fa-download"
+                id="Icon99"
+              />
+              Download full report (CSV)
+            </button>
+          </div>
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="col-12 pr-md-0 mb-0"
           >
             <div
-              className="row"
+              className="row w-100 m-0"
             >
               <div
-                className="col-sm-12 col-md-7 pr-md-0 mb-1"
+                className="col-12 col-md-6 px-0"
               >
+                <form
+                  className="form-inline"
+                  role="search"
+                >
+                  <div
+                    className="col-6 pl-0 pr-md-2 pr-lg-3"
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="search-label mb-2 form-label"
+                        id="course-title-search"
+                      >
+                        Filter by course
+                      </label>
+                      <select
+                        aria-labelledby="course-title-search"
+                        className="w-100 form-control"
+                        onChange={[Function]}
+                      >
+                        <option
+                          value=""
+                        >
+                          All Courses
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    className="col-6 pr-0 px-md-2 px-lg-3"
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="search-label mb-2 form-label"
+                        id="date-search"
+                      >
+                        Filter by start date
+                      </label>
+                      <select
+                        aria-labelledby="date-search"
+                        className="w-100 form-control"
+                        disabled={true}
+                        onChange={[Function]}
+                      >
+                        <option
+                          value=""
+                        >
+                          Choose a course
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                </form>
+              </div>
+              <div
+                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+              >
+                <label
+                  className="mb-2 form-label"
+                  id="search-email-label"
+                >
+                  Filter by email
+                </label>
                 <div
-                  className="pgn__searchfield d-flex"
+                  className="pgn__searchfield d-flex py-0"
                 >
                   <form
                     className="d-flex align-items-center w-100"
@@ -2309,7 +2398,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                   >
                     <label
                       className="m-0"
-                      htmlFor="pgn-searchfield-input-99"
+                      htmlFor="pgn-searchfield-input-100"
                     >
                       <span
                         className="sr-only"
@@ -2319,7 +2408,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                     </label>
                     <input
                       className="form-control"
-                      id="pgn-searchfield-input-99"
+                      id="pgn-searchfield-input-100"
                       name="searchfield-input"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -2358,25 +2447,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                     </button>
                   </form>
                 </div>
-              </div>
-              <div
-                className="col-sm-12 col-md-5 pl-md-0"
-              >
-                <button
-                  className="btn btn-outline-primary download-btn d-sm-inline float-right"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon100"
-                  />
-                  Download full report (CSV)
-                </button>
               </div>
             </div>
           </div>
@@ -2899,25 +2969,114 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-8 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
+          >
+            <button
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              type="button"
+            >
+              <span
+                aria-hidden={true}
+                className="fa mr-2 fa-download"
+                id="Icon9"
+              />
+              Download full report (CSV)
+            </button>
+          </div>
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="col-12 pr-md-0 mb-0"
           >
             <div
-              className="row"
+              className="row w-100 m-0"
             >
               <div
-                className="col-sm-12 col-md-7 pr-md-0 mb-1"
+                className="col-12 col-md-6 px-0"
               >
+                <form
+                  className="form-inline"
+                  role="search"
+                >
+                  <div
+                    className="col-6 pl-0 pr-md-2 pr-lg-3"
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="search-label mb-2 form-label"
+                        id="course-title-search"
+                      >
+                        Filter by course
+                      </label>
+                      <select
+                        aria-labelledby="course-title-search"
+                        className="w-100 form-control"
+                        onChange={[Function]}
+                      >
+                        <option
+                          value=""
+                        >
+                          All Courses
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    className="col-6 pr-0 px-md-2 px-lg-3"
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="search-label mb-2 form-label"
+                        id="date-search"
+                      >
+                        Filter by start date
+                      </label>
+                      <select
+                        aria-labelledby="date-search"
+                        className="w-100 form-control"
+                        disabled={true}
+                        onChange={[Function]}
+                      >
+                        <option
+                          value=""
+                        >
+                          Choose a course
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                </form>
+              </div>
+              <div
+                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+              >
+                <label
+                  className="mb-2 form-label"
+                  id="search-email-label"
+                >
+                  Filter by email
+                </label>
                 <div
-                  className="pgn__searchfield d-flex"
+                  className="pgn__searchfield d-flex py-0"
                 >
                   <form
                     className="d-flex align-items-center w-100"
@@ -2927,7 +3086,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                   >
                     <label
                       className="m-0"
-                      htmlFor="pgn-searchfield-input-9"
+                      htmlFor="pgn-searchfield-input-10"
                     >
                       <span
                         className="sr-only"
@@ -2937,7 +3096,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                     </label>
                     <input
                       className="form-control"
-                      id="pgn-searchfield-input-9"
+                      id="pgn-searchfield-input-10"
                       name="searchfield-input"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -2976,25 +3135,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                     </button>
                   </form>
                 </div>
-              </div>
-              <div
-                className="col-sm-12 col-md-5 pl-md-0"
-              >
-                <button
-                  className="btn btn-outline-primary download-btn d-sm-inline float-right"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon10"
-                  />
-                  Download full report (CSV)
-                </button>
               </div>
             </div>
           </div>
@@ -3535,19 +3675,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -4099,19 +4239,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -4661,19 +4801,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -5220,19 +5360,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -5784,19 +5924,19 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
         className="col"
       >
         <div
-          className="row"
+          className="row pb-3"
         >
           <div
-            className="col-12 col-md-12 col-lg-12 col-xl-4 pt-1 pb-3"
+            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
           >
             Showing data as of 
             July 31, 2018
           </div>
           <div
-            className="col-12 col-md-6 col-lg-12 text-md-right"
+            className="col-12 col-md-6 col-xl-8"
           >
             <button
-              className="btn btn-outline-primary download-btn d-sm-inline float-right"
+              className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}

--- a/src/components/DownloadCsvButton/index.jsx
+++ b/src/components/DownloadCsvButton/index.jsx
@@ -18,7 +18,7 @@ class DownloadCsvButton extends React.Component {
     const downloadButtonIconClasses = csvLoading ? ['fa-spinner', 'fa-spin'] : ['fa-download'];
     return (
       <Button
-        className="btn-outline-primary download-btn d-sm-inline float-right"
+        className="btn-outline-primary download-btn d-sm-inline float-md-right"
         disabled={disabled || csvLoading}
         onClick={() => fetchCsv(fetchMethod)}
       >

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`CouponDetailsWrapper renders does not show Assign button for an unavail
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -608,7 +608,7 @@ exports[`CouponDetailsWrapper renders with assignment and reminder dates table d
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -1222,7 +1222,7 @@ exports[`CouponDetailsWrapper renders with assignment and reminder dates table d
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -1836,7 +1836,7 @@ exports[`CouponDetailsWrapper renders with assignment and reminder dates table d
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -2461,7 +2461,7 @@ exports[`CouponDetailsWrapper renders with error 1`] = `
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -2714,7 +2714,7 @@ exports[`CouponDetailsWrapper renders with expanded coupon details 1`] = `
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -2923,7 +2923,7 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
         className="col-12 col-md-6 mb-2 mb-md-0 text-md-right"
       >
         <button
-          className="btn btn-outline-primary download-btn d-sm-inline float-right"
+          className="btn btn-outline-primary download-btn d-sm-inline float-md-right"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,8 @@ const getPageOptionsFromUrl = () => {
     page: 1,
     ordering: undefined,
     search: undefined,
+    search_course: undefined,
+    search_start_date: undefined,
   };
   const query = qs.parse(window.location.search);
   return {
@@ -71,6 +73,8 @@ const getPageOptionsFromUrl = () => {
     page: parseInt(query.page, 10) || defaults.page,
     ordering: query.ordering || defaults.ordering,
     search: query.search || defaults.search,
+    search_course: query.search_course || defaults.search_course,
+    search_start_date: query.search_start_date || defaults.search_start_date,
   };
 };
 


### PR DESCRIPTION
This adds a course title and a date filter to the admin portal. 

MIRO Board: https://miro.com/app/board/o9J_kp-7aks=/?moveToWidget=3074457348864300777&cot=13

**Notes for review**
The backend has been updated but not merged, so you will need to be on the `ENT-3086` filters branch of `edx-enterprise-data` (installed into `edx-analytics-data-api`, similarly to how we installed `edx-enterprise` into `edx-platform`) in order to review this properly.

I created courses and learners by using the EnterpriseEnrollmentFactory in the django shell.

The date field is disabled until a course title has been selected.

There are plans for a form reset button and some help text in a pop-over, but I'm going to open another ticket for those because the design has not been finalized.

