### PR TITLE
ENH- adding country attr to SAML config form

### DIFF
--- a/src/components/SamlConfiguration/SamlProviderConfigForm.jsx
+++ b/src/components/SamlConfiguration/SamlProviderConfigForm.jsx
@@ -283,6 +283,22 @@ class SamlProviderConfigForm extends React.Component {
             </ValidationFormGroup>
           </div>
         </div>
+        <div className="row">
+          <div className="col col-4">
+            <ValidationFormGroup
+              for="country"
+              helpText="URN of SAML attribute containing the user's country"
+            >
+              <label htmlFor="country">Country</label>
+              <Input
+                type="text"
+                id="country"
+                name="country"
+                defaultValue={config ? config.country : ''}
+              />
+            </ValidationFormGroup>
+          </div>
+        </div>
 
         <div className="row">
           <div className="col col-2">
@@ -352,6 +368,7 @@ SamlProviderConfigForm.propTypes = {
     attrEmail: PropTypes.string,
     maxSessionLength: PropTypes.number,
     id: PropTypes.number,
+    country: PropTypes.string,
   }),
 };
 

--- a/src/components/SamlConfiguration/index.test.jsx
+++ b/src/components/SamlConfiguration/index.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SamlConfiguration from './index';
+import LmsApiService from './../../data/services/LmsApiService';
+import { REQUIRED_DATA_FIELDS } from './SamlProviderDataForm';
+
+const formData = new FormData();
+const responseData = { data: {} };
+const oldConfig = { };
+REQUIRED_DATA_FIELDS.forEach((field) => {
+  formData.append(field, 'testdata');
+  responseData.data[field] = 'testdata';
+  oldConfig[field] = 'oldtestdata';
+});
+
+describe('<SamlConfiguration /> ', () => {
+  it('creating provider config states', () => {
+    const wrapper = shallow(<SamlConfiguration enterpriseId="testEnterpriseId" />);
+    const spyPostNewProviderConfig = jest.spyOn(LmsApiService, 'postNewProviderConfig');
+
+    spyPostNewProviderConfig.mockImplementation(() => responseData);
+    wrapper.instance().createProviderConfig(formData, () => {
+      expect(wrapper.state().providerConfig).toEqual(responseData.data);
+    });
+  });
+
+  it('updating provider config states', () => {
+    const wrapper = shallow(<SamlConfiguration enterpriseId="testEnterpriseId" />);
+    const spyPostUpdatedProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');
+    wrapper.setState({ providerConfig: oldConfig });
+
+    spyPostUpdatedProviderConfig.mockImplementation(() => responseData);
+    wrapper.instance().updateProviderConfig(formData, () => {
+      expect(wrapper.state().providerConfig).toEqual(responseData.data);
+    });
+  });
+
+  it('deleting provider config resets states', () => {
+    const wrapper = shallow(<SamlConfiguration enterpriseId="testEnterpriseId" />);
+    const spyPostDeletedProviderConfig = jest.spyOn(LmsApiService, 'deleteProviderConfig');
+
+    wrapper.setState({ providerConfig: oldConfig });
+    spyPostDeletedProviderConfig.mockImplementation(() => {});
+    wrapper.instance().deleteProviderConfig(formData, () => {
+      expect(wrapper.state().providerConfig).toEqual(undefined);
+    });
+  });
+
+  it('handling response errors', () => {
+    const wrapper = shallow(<SamlConfiguration enterpriseId="testEnterpriseId" />);
+
+    const errorMessage = 'test error message.';
+    const spyPostUpdatedProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');
+    spyPostUpdatedProviderConfig.mockImplementation(() => {
+      throw new Error(errorMessage);
+    });
+    expect(wrapper.instance().updateProviderConfig(formData)).resolves.toEqual(errorMessage);
+  });
+});


### PR DESCRIPTION
Related [backend PR](https://github.com/edx/edx-platform/pull/24560) -- **Merged**

Saml config [ground work PR]( https://github.com/edx/frontend-app-admin-portal/commit/49e2cfd2e7da36b01db3e210a3da2ee8f6205d22)    -- **Merged** 

We want an end user to have the ability to include their IDP's country attr URN along with the rest of their SAML config data and have the country be included in the backend Django Admin config creation. The linked backend PR above has backwards compatibly added country as a new field in the model. This PR adds country as an additional text input to the config form. 

Additionally added state change tests and slightly padded out the unit tests for Saml configs.  