### PR TITLE
BUG: Fix saml response display

### DIFF
--- a/src/components/SamlConfiguration/index.jsx
+++ b/src/components/SamlConfiguration/index.jsx
@@ -21,13 +21,13 @@ class SamlConfiguration extends React.Component {
   };
 
   componentDidMount() {
-    Promise.all([
+    Promise.allSettled([
       LmsApiService.getProviderConfig(this.props.enterpriseId),
       LmsApiService.getProviderData(this.props.enterpriseId),
     ]).then((responses) => {
       this.setState({
-        providerConfig: responses[0].data.results[0],
-        providerData: responses[1].data.results[0],
+        providerConfig: responses[0].status === 'fulfilled' ? responses[0].value.data.results[0] : undefined,
+        providerData: responses[1].status === 'fulfilled' ? responses[1].value.data.results[0] : undefined,
         loading: false,
       });
     })


### PR DESCRIPTION
While testing changes when fixing another bug, I realized provider config was not displaying if data was 404'ing. This is due to using promise.all instead of promise.settled.

Switching to promise.settled allows us to still resolve providerConfig and providerData gets simultaneously, but ensures we can display config even if the data call fails.

### Testing notes:
- Have latest master branch of edx-platform
- Make sure LMS is running.
- Make sure you have an enterprise user associated with an enterprise customer and that user has an operator or admin enterprise system wide role configured.
- Enable the saml portal in LMS admin:
  - `localhost:18000/admin/enterprise/enterprisecustomer`
  - Click on the name of an enterprise customer (thus navigating to the enterprise customer details).
  - Scroll towards the bottom and check the box next to `Enable portal saml configuration screen`
  - Make sure to click the save button at the very bottom.
- after downloading/installing this repo, run the server with `npm start`
- Navigate to localhost:1991 (if redirected to :18000 for login, just login with a user and navigate again to locahost:1991)
- Create a provider config in the admin portal (port 1991).
- Reload the admin portal and verify you can see the new config. (Previously it would not show if provider data is not present)