### PR TITLE
Put the JwtAuthenticationRefresh wrapper outside of the ConnectedRouter.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,8 +39,8 @@ if (configuration.FULLSTORY_ORG_ID) {
 
 const AppWrapper = () => (
   <Provider store={store}>
-    <ConnectedRouter history={history}>
-      <JwtAuthenticationRefresh>
+    <JwtAuthenticationRefresh>
+      <ConnectedRouter history={history}>
         <React.Fragment>
           <Helmet
             titleTemplate="%s - edX Admin Portal"
@@ -81,8 +81,8 @@ const AppWrapper = () => (
           </Switch>
           <Footer />
         </React.Fragment>
-      </JwtAuthenticationRefresh>
-    </ConnectedRouter>
+      </ConnectedRouter>
+    </JwtAuthenticationRefresh>
   </Provider>
 );
 


### PR DESCRIPTION
Fixes a bug where the enterprise customers weren't routing us to their portal and broke routing around different admin actions.