### PR TITLE
add auto remind email checkbox

### DIFF
--- a/src/components/CodeAssignmentModal/CodeAssignmentModal.scss
+++ b/src/components/CodeAssignmentModal/CodeAssignmentModal.scss
@@ -16,4 +16,8 @@
       margin-bottom: 6px;
     }
   }
+
+  .auto-reminder-warpper label {
+    line-height: unset;
+  }
 }

--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
-import { Button, Icon, Modal } from '@edx/paragon';
+import { Button, Input, Icon, Modal } from '@edx/paragon';
 import isEmail from 'validator/lib/isEmail';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 import TextAreaAutoSize from '../TextAreaAutoSize';
 import RenderField from '../RenderField';
@@ -12,6 +13,7 @@ import BulkAssignFields from './BulkAssignFields';
 import IndividualAssignFields from './IndividualAssignFields';
 import SaveTemplateButton from '../../containers/SaveTemplateButton';
 import TemplateSourceFields from '../../containers/TemplateSourceFields';
+import IconWithTooltip from '../IconWithTooltip';
 
 import { validateEmailTemplateFields } from '../../utils';
 import { ONCE_PER_CUSTOMER, MULTI_USE, CSV_HEADER_NAME } from '../../data/constants/coupons';
@@ -35,6 +37,7 @@ class BaseCodeAssignmentModal extends React.Component {
     this.validateFormData = this.validateFormData.bind(this);
     this.handleModalSubmit = this.handleModalSubmit.bind(this);
     this.getNumberOfSelectedCodes = this.getNumberOfSelectedCodes.bind(this);
+    this.autoReminderField = this.autoReminderField.bind(this);
   }
 
   componentDidMount() {
@@ -315,6 +318,7 @@ class BaseCodeAssignmentModal extends React.Component {
       template_subject: formData['email-template-subject'],
       template_greeting: formData['email-template-greeting'],
       template_closing: formData['email-template-closing'],
+      enable_nudge_emails: formData['enable-nudge-emails'],
     };
 
     // If the enterprise has a learner portal, we should direct users to it in our assignment email
@@ -359,6 +363,27 @@ class BaseCodeAssignmentModal extends React.Component {
           _error: errors,
         });
       });
+  }
+
+  autoReminderField({ input }) {
+    return (
+      <div className="auto-reminder-warpper">
+        <label className="ml-4">
+          <Input
+            {...input}
+            type="checkbox"
+            checked={input.value}
+            id="autoReminderCheckbox"
+          />
+          Automate reminders
+        </label>
+        <IconWithTooltip
+          icon={faInfoCircle}
+          altText="More information"
+          tooltipText="edX will remind learners to redeem their code 3, 10, and 19 days after you assign it."
+        />
+      </div>
+    );
   }
 
   renderBody() {
@@ -418,6 +443,10 @@ class BaseCodeAssignmentModal extends React.Component {
               name="email-template-closing"
               component={TextAreaAutoSize}
               label="Customize Closing"
+            />
+            <Field
+              name="enable-nudge-emails"
+              component={this.autoReminderField}
             />
           </div>
         </form>

--- a/src/containers/CodeAssignmentModal/index.jsx
+++ b/src/containers/CodeAssignmentModal/index.jsx
@@ -5,12 +5,19 @@ import CodeAssignmentModal from '../../components/CodeAssignmentModal';
 import sendCodeAssignment from '../../data/actions/codeAssignment';
 import { EMAIL_TEMPLATE_SOURCE_NEW_EMAIL } from '../../data/constants/emailTemplate';
 
-const mapStateToProps = state => ({
-  couponDetailsTable: state.table['coupon-details'],
-  initialValues: state.emailTemplate.emailTemplateSource === EMAIL_TEMPLATE_SOURCE_NEW_EMAIL ?
-    state.emailTemplate.default.assign : state.emailTemplate.assign,
-  enableReinitialize: true,
-});
+const mapStateToProps = (state) => {
+  let initialValues = state.emailTemplate.emailTemplateSource === EMAIL_TEMPLATE_SOURCE_NEW_EMAIL ?
+    state.emailTemplate.default.assign : state.emailTemplate.assign;
+
+  // By default `Automate reminders` are enabled for code assignments
+  initialValues = { ...initialValues, 'enable-nudge-emails': true };
+
+  return {
+    couponDetailsTable: state.table['coupon-details'],
+    initialValues,
+    enableReinitialize: true,
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   sendCodeAssignment: (couponId, options) => new Promise((resolve, reject) => {


### PR DESCRIPTION
**Description:** Add a checkbox to enable/disable auto reminder emails. Frontend will send `email_auto_reminder` field in assign data to backend. The value (`true/false`) of this field will tell whether we need to enable or disable the automatic reminder emails for the assigned learners.

**JIRA:** [ENT-3488](https://openedx.atlassian.net/browse/ENT-3488)

