### PR TITLE
Add subscription expiration experience for admins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1245,6 +1245,24 @@
         "snakecase-keys": "^2.1.0",
         "universal-cookie": "^3.0.4",
         "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "universal-cookie": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-3.1.0.tgz",
+          "integrity": "sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==",
+          "requires": {
+            "@types/cookie": "^0.3.1",
+            "@types/object-assign": "^4.0.30",
+            "cookie": "^0.3.1",
+            "object-assign": "^4.1.0"
+          }
+        }
       }
     },
     "@edx/frontend-logging": {
@@ -2320,7 +2338,7 @@
     },
     "@types/tapable": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.5.tgz",
+      "resolved": "http://registry.npmjs.org/@types/tapable/-/tapable-0.2.5.tgz",
       "integrity": "sha512-dEoVvo/I9QFomyhY+4Q6Qk+I+dhG59TYceZgC6Q0mCifVPErx6Y83PNTKGDS5e9h9Eti6q0S2mm16BU6iQK+3w==",
       "dev": true
     },
@@ -2599,7 +2617,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -2608,7 +2626,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -2718,7 +2736,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -2988,7 +3006,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -3022,7 +3040,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
@@ -3120,7 +3138,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3332,7 +3350,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-current-node-syntax": {
@@ -3664,7 +3682,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true
         },
@@ -3721,7 +3739,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -3878,7 +3896,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3915,7 +3933,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -4536,7 +4554,7 @@
     },
     "clean-webpack-plugin": {
       "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
+      "resolved": "http://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
       "integrity": "sha512-M1Li5yLHECcN2MahoreuODul5LkjohJGFxLPTjl3j1ttKrF5rgjZET1SJduuqxLAuT1gAPOdkhg03qcaaU1KeA==",
       "dev": true,
       "requires": {
@@ -4894,9 +4912,9 @@
       }
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -5019,7 +5037,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -5032,7 +5050,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5076,7 +5094,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -5578,13 +5596,13 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
@@ -5830,7 +5848,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -6373,7 +6391,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -6452,7 +6470,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -6722,7 +6740,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -6813,7 +6831,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
@@ -7115,7 +7133,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
@@ -7196,7 +7214,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
@@ -7338,7 +7356,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -7380,7 +7398,7 @@
     },
     "file-loader": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
       "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
       "dev": true,
       "requires": {
@@ -7402,7 +7420,7 @@
     },
     "file-saver": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
     },
     "file-type": {
@@ -7812,7 +7830,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -7857,13 +7875,13 @@
         },
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         }
@@ -7986,7 +8004,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -8372,7 +8390,7 @@
     },
     "html-webpack-harddisk-plugin": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-0.2.0.tgz",
       "integrity": "sha1-RlQUpTQhm2nB/YEntYX42GiX+y0=",
       "dev": true,
       "requires": {
@@ -8391,7 +8409,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -8605,7 +8623,7 @@
     },
     "humanize-url": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
       "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
       "dev": true,
       "requires": {
@@ -9043,7 +9061,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "dev": true,
       "requires": {
@@ -9077,7 +9095,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -9154,7 +9172,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -9196,7 +9214,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -9290,7 +9308,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -11867,7 +11885,7 @@
       "dependencies": {
         "query-string": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
           "integrity": "sha1-fbBmZCCAS6qSrp8miWKFWnYUPfs=",
           "requires": {
             "strict-uri-encode": "^1.0.0"
@@ -11941,7 +11959,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -11957,7 +11975,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -12794,7 +12812,7 @@
     },
     "npmlog": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "dev": true,
       "requires": {
@@ -13001,7 +13019,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13073,7 +13091,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -13085,7 +13103,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -13128,7 +13146,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -13311,7 +13329,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -14293,7 +14311,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -14490,7 +14508,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -14512,7 +14530,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -14855,7 +14873,7 @@
     },
     "react-spinners": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/react-spinners/-/react-spinners-0.3.2.tgz",
       "integrity": "sha512-SZzc99QqKLq85uGWYvkVeHTEPMEpLwnvQOyY62vNqAT9WWdkGJgHKt4H7Z68ALiWYZGKT5oIclh/cdBX20546w==",
       "requires": {
         "emotion": "^9.1.1",
@@ -15206,7 +15224,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
@@ -15496,7 +15514,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -15704,7 +15722,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -16153,7 +16171,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -16686,7 +16704,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -16715,7 +16733,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17033,7 +17051,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -17078,7 +17096,7 @@
     },
     "style-loader": {
       "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
+      "resolved": "http://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
       "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
       "dev": true,
       "requires": {
@@ -17278,7 +17296,7 @@
     },
     "tabtab": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
       "integrity": "sha1-egR/FDsBC0y9MfhX6ClhUSy/ThQ=",
       "dev": true,
       "requires": {
@@ -17479,7 +17497,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -17725,7 +17743,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -17905,14 +17923,12 @@
       }
     },
     "universal-cookie": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-3.1.0.tgz",
-      "integrity": "sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
       "requires": {
-        "@types/cookie": "^0.3.1",
-        "@types/object-assign": "^4.0.30",
-        "cookie": "^0.3.1",
-        "object-assign": "^4.1.0"
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {
@@ -19034,7 +19050,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "redux-thunk": "^2.2.0",
     "regenerator-runtime": "^0.13.5",
     "tableau-react-embed": "^1.1.0",
+    "universal-cookie": "^4.0.4",
     "validator": "^10.11.0"
   },
   "devDependencies": {

--- a/src/components/subscriptions/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationBanner.jsx
@@ -1,0 +1,49 @@
+import React, { useContext } from 'react';
+import { MailtoLink } from '@edx/paragon';
+
+import StatusAlert from '../../components/StatusAlert';
+import { SubscriptionContext } from './SubscriptionData';
+import {
+  SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD,
+  SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD,
+  SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD,
+} from './constants';
+
+export default function SubscriptionExpirationBanner() {
+  const { details } = useContext(SubscriptionContext);
+  const { daysUntilExpiration } = details;
+
+  const renderMessage = () => (
+    <React.Fragment>
+      Your subscription is {daysUntilExpiration} days from expiration.
+      Contact the edX Customer Success team at
+      {' '}
+      <MailtoLink to="customersuccess@edx.org">customersuccess@edx.org</MailtoLink>
+      {' '}
+      to extend your contract.
+    </React.Fragment>
+  );
+
+  if (daysUntilExpiration > SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD) {
+    return null;
+  }
+
+  let dismissible = true;
+  let alertType = 'info';
+  if (daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD) {
+    alertType = 'warning';
+  }
+  if (daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD) {
+    dismissible = false;
+    alertType = 'danger';
+  }
+
+  return (
+    <StatusAlert
+      className="mt-1"
+      alertType={alertType}
+      message={renderMessage(daysUntilExpiration)}
+      dismissible={dismissible}
+    />
+  );
+}

--- a/src/components/subscriptions/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationBanner.jsx
@@ -40,7 +40,7 @@ export default function SubscriptionExpirationBanner() {
 
   return (
     <StatusAlert
-      className="mt-1"
+      className="expiration-alert mt-1"
       alertType={alertType}
       message={renderMessage(daysUntilExpiration)}
       dismissible={dismissible}

--- a/src/components/subscriptions/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationBanner.jsx
@@ -4,9 +4,9 @@ import { MailtoLink } from '@edx/paragon';
 import StatusAlert from '../../components/StatusAlert';
 import { SubscriptionContext } from './SubscriptionData';
 import {
-  SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD,
-  SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD,
-  SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD,
+  SUBSCRIPTION_DAYS_REMAINING_MODERATE,
+  SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+  SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
 } from './constants';
 
 export default function SubscriptionExpirationBanner() {
@@ -24,16 +24,16 @@ export default function SubscriptionExpirationBanner() {
     </React.Fragment>
   );
 
-  if (daysUntilExpiration > SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD) {
+  if (daysUntilExpiration > SUBSCRIPTION_DAYS_REMAINING_MODERATE) {
     return null;
   }
 
   let dismissible = true;
   let alertType = 'info';
-  if (daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD) {
+  if (daysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
     alertType = 'warning';
   }
-  if (daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD) {
+  if (daysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL) {
     dismissible = false;
     alertType = 'danger';
   }

--- a/src/components/subscriptions/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationBanner.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SubscriptionExpirationBanner from './SubscriptionExpirationBanner';
+import { SubscriptionContext } from './SubscriptionData';
+import {
+  SUBSCRIPTION_DAYS_REMAINING_MODERATE,
+  SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+  SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
+} from './constants';
+import { addDays, getSubscriptionExpirationDetails } from './test-utils';
+
+
+/* eslint-disable react/prop-types */
+const BannerWithContext = ({
+  subscriptionState = {},
+}) => (
+  <SubscriptionContext.Provider value={subscriptionState}>
+    <SubscriptionExpirationBanner />
+  </SubscriptionContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<SubscriptionExpirationBanner />', () => {
+  test('does not render an alert before the "moderate" days until expiration threshold', () => {
+    const daysUntilExpiration = SUBSCRIPTION_DAYS_REMAINING_MODERATE + 1;
+    // The actual date isn't relevant here, just how many days until expiration
+    const subscriptionState = getSubscriptionExpirationDetails(
+      daysUntilExpiration,
+      addDays(new Date(), daysUntilExpiration),
+    );
+
+    const wrapper = mount(<BannerWithContext subscriptionState={subscriptionState} />);
+    expect(wrapper.exists('.expiration-alert')).toEqual(false);
+  });
+
+  test('renders an alert after any expiration threshold has passed', () => {
+    const thresholds = [
+      SUBSCRIPTION_DAYS_REMAINING_MODERATE,
+      SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+      SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
+    ];
+    Object.values(thresholds).forEach((threshold) => {
+      const daysUntilExpiration = threshold - 1;
+      // The actual date isn't relevant here, just how many days until expiration
+      const subscriptionState = getSubscriptionExpirationDetails(
+        daysUntilExpiration,
+        addDays(new Date(), daysUntilExpiration),
+      );
+
+      const wrapper = mount(<BannerWithContext subscriptionState={subscriptionState} />);
+      expect(wrapper.exists('.expiration-alert')).toEqual(true);
+    });
+  });
+});

--- a/src/components/subscriptions/SubscriptionExpirationModal.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationModal.jsx
@@ -1,0 +1,137 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { Modal, MailtoLink } from '@edx/paragon';
+import Cookies from 'universal-cookie';
+
+import { SubscriptionContext } from './SubscriptionData';
+import {
+  SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD,
+  SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD,
+  SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD,
+  SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX,
+} from './constants';
+
+import Img from '../../components/Img';
+import edxLogo from '../../images/edx-logo.png';
+import { formatTimestamp } from '../../utils';
+
+
+function SubscriptionExpirationModal({ enterpriseSlug }) {
+  const { details } = useContext(SubscriptionContext);
+  const { daysUntilExpiration, expirationDate } = details;
+
+  const renderTitle = () => (
+    <small>Renew your subscription</small>
+  );
+
+  const renderBody = () => (
+    <React.Fragment>
+      <p>
+        Your current subscription is set to expire in {daysUntilExpiration} days.
+        In order to minimize course access disruptions for your learners, make sure your invoice has
+        been completed.
+      </p>
+      <p>
+        If you have questions or need help, please contact the edX Customer Success team at
+        {' '}
+        <MailtoLink to="customersuccess@edx.org">customersuccess@edx.org</MailtoLink>.
+      </p>
+      <i>
+        Access expires on {formatTimestamp({ timestamp: expirationDate })}
+      </i>
+    </React.Fragment>
+  );
+
+  const renderExpiredBody = () => (
+    <React.Fragment>
+      <Img className="w-25 my-5 mx-auto d-block" src={edxLogo} alt="edX logo" />
+      <p>
+        Your subscription license expired on {formatTimestamp({ timestamp: expirationDate })}.
+        To access your subscription management page contact edX and reactivate your subscriptions.
+      </p>
+      <p>
+        What to do next?
+      </p>
+      <ul>
+        <li>
+          To reactivate your subscriptions please cotact the edX Customer Success team at
+          {' '}
+          <MailtoLink to="customersuccess@edx.org">customersuccess@edx.org</MailtoLink>
+        </li>
+        <li>
+          View your learner progress in the <Link to={`/${enterpriseSlug}/admin/learners`}>learner management page</Link>
+        </li>
+        <li>
+          Manage your codes in the <Link to={`/${enterpriseSlug}/admin/coupons`}>code management page</Link>
+        </li>
+      </ul>
+    </React.Fragment>
+  );
+
+  // If the subscription has already expired, we show a different un-dismissible modal
+  const subscriptionExpired = daysUntilExpiration <= 0;
+  if (subscriptionExpired) {
+    return (
+      <Modal
+        renderHeaderCloseButton={false}
+        renderDefaultCloseButton={false}
+        title={null}
+        body={renderExpiredBody()}
+        open
+      />
+    );
+  }
+
+  if (daysUntilExpiration > SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD) {
+    return null;
+  }
+
+  let expirationThreshold = SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD;
+  if (details.daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD) {
+    expirationThreshold = SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD;
+  }
+  if (daysUntilExpiration <= SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD) {
+    expirationThreshold = SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD;
+  }
+  const seenCurrentExpirationModalCookieName = `${SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX}${expirationThreshold}`;
+  const cookies = new Cookies();
+  const seenCurrentExpirationModal = cookies.get(seenCurrentExpirationModalCookieName);
+  // If they have already seen the expiration modal for their current threshold (as deterrmined by
+  // the cookie), don't show them anything
+  if (seenCurrentExpirationModal) {
+    return null;
+  }
+
+  return (
+    <Modal
+      renderHeaderCloseButton={false}
+      title={renderTitle()}
+      body={renderBody()}
+      closeText="Ok"
+      // Mark that the user has seen this threshold's expiration modal when they close it
+      onClose={() => {
+        cookies.set(
+          seenCurrentExpirationModalCookieName,
+          true,
+          // Cookies without the `sameSite` attribute are rejected if they are missing the `secure`
+          // attribute. See
+          // https//developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+          { sameSite: 'strict' },
+        );
+      }}
+      open
+    />
+  );
+}
+
+SubscriptionExpirationModal.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+});
+
+export default connect(mapStateToProps)(SubscriptionExpirationModal);

--- a/src/components/subscriptions/SubscriptionExpirationModal.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationModal.jsx
@@ -51,14 +51,14 @@ export function BaseSubscriptionExpirationModal({ enterpriseSlug, enableCodeMana
       <Img className="w-25 my-5 mx-auto d-block" src={edxLogo} alt="edX logo" />
       <p>
         Your subscription license expired on {formatTimestamp({ timestamp: expirationDate })}.
-        To access your subscription management page contact edX and reactivate your subscriptions.
+        To access your subscription management page contact edX and reactivate your subscription(s).
       </p>
       <p>
         What to do next?
       </p>
       <ul>
         <li>
-          To reactivate your subscriptions please contact the edX Customer Success team at
+          To reactivate your subscription(s) please contact the edX Customer Success team at
           {' '}
           <MailtoLink to="customersuccess@edx.org">customersuccess@edx.org</MailtoLink>
         </li>

--- a/src/components/subscriptions/SubscriptionExpirationModal.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationModal.jsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import Cookies from 'universal-cookie';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Modal, MailtoLink } from '@edx/paragon';
-import Cookies from 'universal-cookie';
 
 import { SubscriptionContext } from './SubscriptionData';
 import {
@@ -17,10 +17,10 @@ import Img from '../../components/Img';
 import edxLogo from '../../images/edx-logo.png';
 import { formatTimestamp } from '../../utils';
 
-const MODAL_DIALOG_CLASS_NAME = 'subscription-expiration';
+export const MODAL_DIALOG_CLASS_NAME = 'subscription-expiration';
 
 
-function SubscriptionExpirationModal({ enterpriseSlug, enableCodeManagementScreen }) {
+export function BaseSubscriptionExpirationModal({ enterpriseSlug, enableCodeManagementScreen }) {
   const { details } = useContext(SubscriptionContext);
   const { daysUntilExpiration, expirationDate } = details;
 
@@ -134,7 +134,7 @@ function SubscriptionExpirationModal({ enterpriseSlug, enableCodeManagementScree
   );
 }
 
-SubscriptionExpirationModal.propTypes = {
+BaseSubscriptionExpirationModal.propTypes = {
   enterpriseSlug: PropTypes.string.isRequired,
   enableCodeManagementScreen: PropTypes.bool.isRequired,
 };
@@ -144,4 +144,5 @@ const mapStateToProps = state => ({
   enableCodeManagementScreen: state.portalConfiguration.enableCodeManagementScreen,
 });
 
-export default connect(mapStateToProps)(SubscriptionExpirationModal);
+const SubscriptionExpirationModal = connect(mapStateToProps)(BaseSubscriptionExpirationModal);
+export default SubscriptionExpirationModal;

--- a/src/components/subscriptions/SubscriptionExpirationModal.test.jsx
+++ b/src/components/subscriptions/SubscriptionExpirationModal.test.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Router, Route } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { Modal } from '@edx/paragon';
+
+import { MODAL_DIALOG_CLASS_NAME, BaseSubscriptionExpirationModal } from './SubscriptionExpirationModal';
+import { SubscriptionContext } from './SubscriptionData';
+import { SUBSCRIPTION_DAYS_REMAINING_MODERATE } from './constants';
+import { addDays, getSubscriptionExpirationDetails } from './test-utils';
+
+
+const history = createMemoryHistory({
+  initialEntries: ['/'],
+});
+
+jest.mock('universal-cookie', () => {
+  const mockCookie = {
+    get: jest.fn(() => true),
+  };
+  return jest.fn(() => mockCookie);
+});
+
+/* eslint-disable react/prop-types */
+const ModalWithContext = ({
+  subscriptionState = {},
+  enableCodeManagementScreen = false,
+}) => (
+  <Router history={history}>
+    <Route exact path="/:enterpriseSlug/admin/subscriptions">
+      <SubscriptionContext.Provider value={subscriptionState}>
+        <BaseSubscriptionExpirationModal
+          enterpriseSlug="test-enterprise"
+          enableCodeManagementScreen={enableCodeManagementScreen}
+        />
+      </SubscriptionContext.Provider>
+    </Route>
+  </Router>
+);
+/* eslint-enable react/prop-types */
+
+describe('<SubscriptionExpirationModal />', () => {
+  test('does not render before the "moderate" days until expiration threshold', () => {
+    const daysUntilExpiration = SUBSCRIPTION_DAYS_REMAINING_MODERATE + 1;
+    const subscriptionState = getSubscriptionExpirationDetails(
+      daysUntilExpiration,
+      addDays(new Date(), daysUntilExpiration),
+    );
+
+    const wrapper = mount(<ModalWithContext subscriptionState={subscriptionState} />);
+    expect(wrapper.exists(Modal)).toEqual(false);
+  });
+
+  test('renders a modal for "post-expiration" if the subscription already expired', () => {
+    const daysUntilExpiration = -1;
+    const subscriptionState = getSubscriptionExpirationDetails(
+      daysUntilExpiration,
+      addDays(new Date(), daysUntilExpiration),
+    );
+
+    const wrapper = mount(<ModalWithContext subscriptionState={subscriptionState} />);
+    const modal = wrapper.find(Modal);
+    expect(modal.prop('dialogClassName')).toEqual(`${MODAL_DIALOG_CLASS_NAME} expired`);
+  });
+
+  test('does not render a modal if we are past an expiration threshold but they have the "seen" cookie', () => {
+    const daysUntilExpiration = SUBSCRIPTION_DAYS_REMAINING_MODERATE - 1;
+    const subscriptionState = getSubscriptionExpirationDetails(
+      daysUntilExpiration,
+      addDays(new Date(), daysUntilExpiration),
+    );
+
+    const wrapper = mount(<ModalWithContext subscriptionState={subscriptionState} />);
+    expect(wrapper.exists(Modal)).toEqual(false);
+  });
+
+  test('renders a modal if we are past an expiration threshold and no cookie says the user has seen it', () => {
+    const daysUntilExpiration = SUBSCRIPTION_DAYS_REMAINING_MODERATE - 1;
+    const subscriptionState = getSubscriptionExpirationDetails(
+      daysUntilExpiration,
+      addDays(new Date(), daysUntilExpiration),
+    );
+
+    const wrapper = mount(<ModalWithContext subscriptionState={subscriptionState} />);
+    const modal = wrapper.find(Modal);
+    expect(modal.prop('dialogClassName')).toEqual(`${MODAL_DIALOG_CLASS_NAME}`);
+  });
+});

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -12,6 +12,8 @@ import SubscriptionDetails from './SubscriptionDetails';
 import AddUsersButton from './AddUsersButton';
 import LicenseAllocationNavigation from './LicenseAllocationNavigation';
 import TabContentTable from './TabContentTable';
+import SubscriptionExpirationBanner from './SubscriptionExpirationBanner';
+import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 
 import { TAB_PENDING_USERS } from './constants';
 
@@ -25,6 +27,8 @@ function SubscriptionManagementPage({ enterpriseSlug, enterpriseId }) {
       <Helmet title={PAGE_TITLE} />
       <Hero title={PAGE_TITLE} />
       <SubscriptionData enterpriseId={enterpriseId}>
+        <SubscriptionExpirationBanner />
+        <SubscriptionExpirationModal />
         <main role="main" className="manage-subscription">
           <div className="container-fluid mt-3">
             <div className="row mb-5">

--- a/src/components/subscriptions/constants.js
+++ b/src/components/subscriptions/constants.js
@@ -23,9 +23,9 @@ export const DEFAULT_PAGE = 1;
 export const SHOW_REVOCATION_CAP_PERCENT = 80;
 
 // Subscription expiration
-// Days until expiration threshold constants
-export const SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD = 120;
-export const SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD = 60;
-export const SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD = 30;
-// Prefix for cookies that determine if the user has seen the modal for that threshold of expiration
+// Days until expiration constants
+export const SUBSCRIPTION_DAYS_REMAINING_MODERATE = 120;
+export const SUBSCRIPTION_DAYS_REMAINING_SEVERE = 60;
+export const SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL = 30;
+// Prefix for cookies that determine if the user has seen the modal for that range of expiration
 export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';

--- a/src/components/subscriptions/constants.js
+++ b/src/components/subscriptions/constants.js
@@ -21,3 +21,11 @@ export const DEFAULT_PAGE = 1;
 
 // used to determine whether to show the revocation cap messaging in the license revoke modal
 export const SHOW_REVOCATION_CAP_PERCENT = 80;
+
+// Subscription expiration
+// Days until expiration threshold constants
+export const SUBSCRIPTION_EXPIRATION_FIRST_THRESHOLD = 120;
+export const SUBSCRIPTION_EXPIRATION_SECOND_THRESHOLD = 60;
+export const SUBSCRIPTION_EXPIRATION_THIRD_THRESHOLD = 30;
+// Prefix for cookies that determine if the user has seen the modal for that threshold of expiration
+export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';

--- a/src/components/subscriptions/styles/_SubscriptionExpirationModal.scss
+++ b/src/components/subscriptions/styles/_SubscriptionExpirationModal.scss
@@ -1,0 +1,14 @@
+.modal-dialog.subscription-expiration {
+  &.expired {
+    .modal-header {
+      padding: 0;
+      border: 0;
+    }
+  }
+
+  .modal-footer {
+    .btn {
+      // TODO: Add .btn-primary styles
+    }
+  }
+}

--- a/src/components/subscriptions/test-utils.js
+++ b/src/components/subscriptions/test-utils.js
@@ -1,0 +1,21 @@
+// Helper function to add the given number of days to the supplied date, handling rollover
+const addDays = (date, days) => {
+  const copy = new Date(Number(date));
+  copy.setDate(date.getDate() + days);
+  return copy;
+};
+
+// Helper to return the appropriate subscription context details for expiration testing
+const getSubscriptionExpirationDetails = (daysUntilExpiration, expirationDate) => (
+  {
+    details: {
+      daysUntilExpiration,
+      expirationDate,
+    },
+  }
+);
+
+export {
+  addDays,
+  getSubscriptionExpirationDetails,
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -19,6 +19,7 @@ $fa-font-path: "~font-awesome/fonts";
 @import "./components/SupportPage/SupportPage";
 @import "./components/subscriptions/styles/LicenseActions";
 @import "./components/subscriptions/styles/SubscriptionManagementPage";
+@import "./components/subscriptions/styles/SubscriptionExpirationModal";
 
 body {
   overflow-x: hidden;


### PR DESCRIPTION
Note that this doesn't provide any sort of post-expiration experience
and there isn't any backend validation preventing admins from doing
things once their subscription expires. That will come later.

ENT-3504

### Modals
**Pre-expiration modal**
![image](https://user-images.githubusercontent.com/14864970/96914587-30f3a300-1473-11eb-9377-de516bd00dbb.png)
**Post-expiration modal**
![image](https://user-images.githubusercontent.com/14864970/97006590-16bad300-150e-11eb-916d-71dca2c368eb.png)




### Banners
**<= 120 day banner:**
![image](https://user-images.githubusercontent.com/14864970/96914404-f7bb3300-1472-11eb-9954-93537b592861.png)

**<= 60 day banner:**
![image](https://user-images.githubusercontent.com/14864970/96914325-d6f2dd80-1472-11eb-8218-cd08704fcf1d.png)

**<= 30 day banner:**
![image](https://user-images.githubusercontent.com/14864970/96914214-b2970100-1472-11eb-989d-cba5d3f0efa3.png)
