### PR TITLE
Reset course search filter label

### DIFF
--- a/src/components/Admin/AdminSearchForm.jsx
+++ b/src/components/Admin/AdminSearchForm.jsx
@@ -50,7 +50,6 @@ class AdminSearchForm extends React.Component {
     } = this.props;
     const courseTitles = new Set(tableData.map(en => en.course_title).sort());
     const courseDates = new Set(tableData.map(en => en.course_start).sort().reverse());
-
     return (
       <div className="row">
         <div className="col-12 pr-md-0 mb-0">
@@ -64,7 +63,7 @@ class AdminSearchForm extends React.Component {
                       className="w-100"
                       as="select"
                       aria-labelledby="course-title-search"
-                      value={searchCourseQuery}
+                      value={searchCourseQuery || ''}
                       onChange={e => this.onCourseSelect(e)}
                     >
                       <option value="">All Courses</option>

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -2405,6 +2405,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                         aria-labelledby="course-title-search"
                         className="w-100 form-control"
                         onChange={[Function]}
+                        value=""
                       >
                         <option
                           value=""
@@ -3127,6 +3128,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                         aria-labelledby="course-title-search"
                         className="w-100 form-control"
                         onChange={[Function]}
+                        value=""
                       >
                         <option
                           value=""


### PR DESCRIPTION
Course search filter was not properly resetting because it's value was undefined
This changes it to the empty string which is the default option of 'All courses'