### PR TITLE
ENT-3657: Fixed a small UI glitch

### DIFF
--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -30,6 +30,7 @@ class CodeRevokeModal extends React.Component {
     this.setDoNotEmail = this.setDoNotEmail.bind(this);
     this.validateFormData = this.validateFormData.bind(this);
     this.handleModalSubmit = this.handleModalSubmit.bind(this);
+    this.doNotEmailField = this.doNotEmailField.bind(this);
   }
 
   componentDidMount() {
@@ -151,13 +152,15 @@ class CodeRevokeModal extends React.Component {
   }
 
   doNotEmailField({ input }) {
+    const { doNotEmail } = this.state;
+
     return (
       <div className="do-not-email-wrapper">
         <label className="ml-4">
           <Input
             {...input}
             type="checkbox"
-            checked={input.value}
+            checked={doNotEmail}
             id="doNotEmailCheckbox"
           />
           Do not email


### PR DESCRIPTION
__Description:__
The UI glitch appeared by following these steps 
1. On the code revoke modal, scroll down the bottom and select the "Do Not Email" checkbox, this will disable email template fields
2. Scroll up and switch between "New Email" and "From Template" tab
3. Scroll down and you will see "Do Not Email" checkbox is not checked, even though the template fields are still disabled.

This PR makes sure that "Do Not Email" checkbox retains its state when switching between "New Email" and "From Template" tab.