### PR TITLE
Fix toggle on number card

### DIFF
--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -78,7 +78,7 @@ class NumberCard extends React.Component {
     }), () => {
       // Wait until after the state is set for the DOM elements
       // to render before we set focus.
-      if (!this.state.detailsExpanded) {
+      if (this.state.detailsExpanded) {
         this.detailActionItemRefs[this.state.focusIndex].focus();
         this.addEvents();
       } else {


### PR DESCRIPTION
A change introduced in the rebrand PR caused undesirable toggle behavior in the number cards, this fixes it.