### PR TITLE
Add zero state for subscription with no allocations

### DIFF
--- a/src/components/subscriptions/AddUsersButton.jsx
+++ b/src/components/subscriptions/AddUsersButton.jsx
@@ -10,8 +10,8 @@ const AddUsersButton = ({
   onClose,
 }) => (
   <ActionButtonWithModal
-    buttonLabel="Add Users"
-    buttonClassName="add-users-btn float-md-right"
+    buttonLabel="Invite Learners"
+    buttonClassName="add-users-btn"
     variant="primary"
     renderModal={({ closeModal }) => (
       <SubscriptionConsumer>
@@ -20,7 +20,7 @@ const AddUsersButton = ({
           details,
         }) => (
           <AddUsersModal
-            title="Add Users"
+            title="Invite Learners"
             availableSubscriptionCount={overview.unassigned}
             subscriptionUUID={details.uuid}
             onSuccess={onSuccess}

--- a/src/components/subscriptions/LicenseAllocationNavigation.jsx
+++ b/src/components/subscriptions/LicenseAllocationNavigation.jsx
@@ -52,6 +52,7 @@ export default function LicenseAllocationNavigation() {
         {tabs.map(tab => (
           <li key={tab.key}>
             <button
+              id={`navigation-${tab.key}`}
               className={classNames(
                 'btn btn-link btn-block pl-0 text-left',
                 { 'font-weight-bold': activeTab === tab.key },

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -15,13 +15,12 @@ import TabContentTable from './TabContentTable';
 import SubscriptionExpirationBanner from './SubscriptionExpirationBanner';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 
-import { TAB_PENDING_USERS } from './constants';
+import { TAB_ALL_USERS, TAB_PENDING_USERS } from './constants';
 
 const PAGE_TITLE = 'Subscription Management';
 
 function SubscriptionManagementPage({ enterpriseSlug, enterpriseId }) {
   const { addToast } = useContext(ToastsContext);
-
   return (
     <>
       <Helmet title={PAGE_TITLE} />
@@ -55,6 +54,7 @@ function SubscriptionManagementPage({ enterpriseSlug, enterpriseId }) {
                       fetchSubscriptionUsers,
                       fetchSubscriptionDetails,
                       setActiveTab,
+                      activeTab,
                     }) => (
                       <>
                         <p className="lead">
@@ -70,7 +70,8 @@ function SubscriptionManagementPage({ enterpriseSlug, enterpriseId }) {
                               onClear={() => fetchSubscriptionUsers()}
                             />
                           </div>
-                          <div className="col-12 col-md-7">
+                          {(details.licenses.allocated > 0 || activeTab !== TAB_ALL_USERS) && (
+                          <div className="col-12 col-md-7 text-md-right">
                             <AddUsersButton
                               onSuccess={({ numAlreadyAssociated, numSuccessfulAssignments }) => {
                                 fetchSubscriptionDetails();
@@ -79,6 +80,7 @@ function SubscriptionManagementPage({ enterpriseSlug, enterpriseId }) {
                               }}
                             />
                           </div>
+                          )}
                         </div>
                       </>
                     )}

--- a/src/components/subscriptions/SubscriptionManagementPage.test.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.test.jsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { createMemoryHistory } from 'history';
+import { Router, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as hooks from './hooks/licenseManagerHooks';
+import { ToastsContext } from '../Toasts';
+import {
+  ASSIGNED, TAB_LICENSED_USERS, TAB_PENDING_USERS, TAB_REVOKED_USERS,
+} from './constants';
+import SubscriptionManagementPage from './SubscriptionManagementPage';
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({
+  authentication: {
+    username: 'edx',
+    roles: ['enterprise_admin:*'],
+  },
+  userAccount: {
+    loaded: true,
+    isActive: true,
+  },
+  portalConfiguration: {
+    enterpriseSlug: 'test-enterprise',
+    enterpriseId: 'test-enterprise-id',
+    enableSubscriptionManagementScreen: true,
+  },
+});
+
+const initialHistory = createMemoryHistory({
+  initialEntries: ['/'],
+});
+
+/* eslint-disable react/prop-types */
+const ManagementPageWithContext = () => (
+  <Router history={initialHistory}>
+    <Provider store={store}>
+      <ToastsContext.Provider value={{ addToast: () => {} }}>
+        <Route
+          exact
+          path="/test-enterprise/admin/subscriptions"
+        >
+          <SubscriptionManagementPage
+            enterpriseSlug="test-enterprise"
+            enterpriseId="a test id"
+          />
+        </Route>
+      </ToastsContext.Provider>
+    </Provider>
+  </Router>
+);
+
+/* eslint-enable react/prop-types */
+
+describe('SubscriptionManagementPage', () => {
+  let mockLoadSubscriptionData = {};
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadSubscriptionData = {
+      fetch: jest.fn(),
+      data: {
+        subscriptions: {
+          pageCount: 1,
+          next: null,
+          previous: null,
+          results: [{
+            title: 'a subscription',
+            uuid: '28d4dcdc-c026-4c02-a263-82dd9c0d8b43',
+            startDate: '2020-12-08',
+            expirationDate: '2025-12-08',
+            enterpriseCustomerUuid: 'b5f07fee-1b34-458f-b672-19b55fc1bd10',
+            enterpriseCatalogUuid: 'ff7acb5e-584a-4e5f-bacc-33a9995794f9',
+            isActive: true,
+            licenses: {
+              total: 10,
+              allocated: 0,
+            },
+            revocations: {
+              applied: 0,
+              remaining: 1,
+            },
+            daysUntilExpiration: 1826,
+          },
+          ],
+        },
+        overview: {},
+        subscriptionUsers: {
+          numPages: 1, next: null, previous: null, results: [],
+        },
+      },
+      isLoading: false,
+      hasSubscription: true,
+    };
+  });
+
+  test('displays the zero state on the default All Users tab with no allocations', () => {
+    jest.spyOn(hooks, 'useSubscriptionData').mockImplementation(() => mockLoadSubscriptionData);
+
+    const wrapper = mount(<ManagementPageWithContext />);
+    expect(wrapper.find('SubscriptionZeroStateMessaging').exists()).toBeTruthy();
+  });
+
+  test('does not display the zero state on All Users tab when there are allocations', () => {
+    mockLoadSubscriptionData.data.subscriptionUsers = {
+      numPages: 1, next: null, previous: null, results: [{ userEmail: 'user@email.com', lastRemindDate: '12-07-2020', status: ASSIGNED }],
+    };
+
+    jest.spyOn(hooks, 'useSubscriptionData').mockImplementation(() => mockLoadSubscriptionData);
+
+    const wrapper = mount(<ManagementPageWithContext />);
+    expect(wrapper.find('SubscriptionZeroStateMessaging').exists()).toBeFalsy();
+  });
+
+  const testTab = (tab) => {
+    jest.spyOn(hooks, 'useSubscriptionData').mockImplementation(() => mockLoadSubscriptionData);
+
+    const wrapper = mount(<ManagementPageWithContext />);
+    wrapper.find(`#navigation-${tab}`).simulate('click');
+    wrapper.update();
+    expect(wrapper.find('SubscriptionZeroStateMessaging').exists()).toBeFalsy();
+  };
+
+  [TAB_PENDING_USERS, TAB_REVOKED_USERS, TAB_LICENSED_USERS].forEach((tab) => {
+    test(`does not display the zero state on ${tab} with no allocations`, () => {
+      testTab(tab);
+    });
+
+    test(`does not display the zero state on ${tab} with allocations`, () => {
+      mockLoadSubscriptionData.data.subscriptionUsers = {
+        numPages: 1, next: null, previous: null, results: [{ userEmail: 'user@email.com', lastRemindDate: '12-07-2020', status: ASSIGNED }],
+      };
+      testTab(tab);
+    });
+  });
+});

--- a/src/components/subscriptions/TabContentTable.jsx
+++ b/src/components/subscriptions/TabContentTable.jsx
@@ -2,7 +2,9 @@ import React, { useContext, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Pagination, Table } from '@edx/paragon';
+import {
+  Card, Pagination, Table,
+} from '@edx/paragon';
 
 import StatusAlert from '../StatusAlert';
 import { ToastsContext } from '../Toasts';
@@ -19,6 +21,7 @@ import {
   TAB_PENDING_USERS,
   TAB_REVOKED_USERS,
 } from './constants';
+import AddUsersButton from './AddUsersButton';
 
 const columns = [
   {
@@ -38,6 +41,7 @@ const columns = [
 function TabContentTable({ enterpriseSlug }) {
   const {
     activeTab,
+    setActiveTab,
     users,
     searchQuery,
     details,
@@ -101,6 +105,24 @@ function TabContentTable({ enterpriseSlug }) {
     [users],
   );
 
+  const SubscriptionZeroStateMessaging = () => (
+    <Card className="text-center">
+      <Card.Body>
+        <h2>Get Started</h2>
+        <p className="py-2 lead">
+          Assign your learners to a subscription license to enable their learning experiences on edX.
+        </p>
+        <AddUsersButton
+          onSuccess={({ numSuccessfulAssignments }) => {
+            fetchSubscriptionDetails();
+            addToast(`${numSuccessfulAssignments} email addresses were successfully added.`);
+            setActiveTab(TAB_PENDING_USERS);
+          }}
+        />
+      </Card.Body>
+    </Card>
+  );
+
   return (
     <>
       <div className="d-flex align-items-center justify-content-between">
@@ -131,49 +153,55 @@ function TabContentTable({ enterpriseSlug }) {
       ))}
       {!isLoading && !errors && (
         <>
-          {tableData?.length > 0 ? (
-            <>
-              {hasNoRevocationsRemaining && (
-                <StatusAlert
-                  alertType="warning"
-                  message={(
-                    <>
-                      You have reached your revoke access limit. For help
-                      managing your subscription licenses,
-                      {' '}
-                      <Link to={`/${enterpriseSlug}/admin/support`} className="alert-link">
-                        contact Customer Support
-                      </Link>.
-                    </>
-                  )}
-                />
-              )}
-              <div className="table-responsive">
-                <Table
-                  data={tableData}
-                  columns={columns}
-                  className="table-striped"
-                />
-              </div>
-              <div className="mt-3 d-flex justify-content-center">
-                <Pagination
-                  onPageSelect={page => fetchSubscriptionUsers({ searchQuery, page })}
-                  pageCount={users.numPages}
-                  currentPage={currentPage}
-                  paginationLabel={activeTabData.paginationLabel}
-                />
-              </div>
-            </>
+          {activeTab === TAB_ALL_USERS && tableData?.length === 0 ? (
+            <SubscriptionZeroStateMessaging />
           ) : (
             <>
-              <hr className="mt-0" />
-              <StatusAlert
-                alertType="warning"
-                title="No results found"
-                message={activeTabData.noResultsLabel}
-                dismissible={false}
-                open
-              />
+              {tableData?.length > 0 ? (
+                <>
+                  {hasNoRevocationsRemaining && (
+                    <StatusAlert
+                      alertType="warning"
+                      message={(
+                        <>
+                          You have reached your revoke access limit. For help
+                          managing your subscription licenses,
+                          {' '}
+                          <Link to={`/${enterpriseSlug}/admin/support`} className="alert-link">
+                            contact Customer Support
+                          </Link>.
+                        </>
+                      )}
+                    />
+                  )}
+                  <div className="table-responsive">
+                    <Table
+                      data={tableData}
+                      columns={columns}
+                      className="table-striped"
+                    />
+                  </div>
+                  <div className="mt-3 d-flex justify-content-center">
+                    <Pagination
+                      onPageSelect={page => fetchSubscriptionUsers({ searchQuery, page })}
+                      pageCount={users.numPages}
+                      currentPage={currentPage}
+                      paginationLabel={activeTabData.paginationLabel}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <hr className="mt-0" />
+                  <StatusAlert
+                    alertType="warning"
+                    title="No results found"
+                    message={activeTabData.noResultsLabel}
+                    dismissible={false}
+                    open
+                  />
+                </>
+              )}
             </>
           )}
         </>


### PR DESCRIPTION
### **Changes Overview:**
Add getting started messaging for when admins view All Users on a subscription that has no allocated licenses on it.

### **Messaging with wide screen:**
![Screen Shot 2020-12-08 at 10 09 36 PM](https://user-images.githubusercontent.com/17459564/101569588-c5be4b80-39a2-11eb-9514-80f6697b77bf.png)

### **Messaging on a smaller screen:**
![Screen Shot 2020-12-08 at 10 09 43 PM](https://user-images.githubusercontent.com/17459564/101569633-dc64a280-39a2-11eb-8d58-69d4935f3313.png)

### **Messaging on a tiny screen:**
![Screen Shot 2020-12-08 at 10 09 51 PM](https://user-images.githubusercontent.com/17459564/101569661-e5557400-39a2-11eb-88e1-f0e5a8bbe2ec.png)

### **Tabs that aren't All Users remain unchanged from how they currently are:**
![Screen Shot 2020-12-08 at 10 10 08 PM](https://user-images.githubusercontent.com/17459564/101569696-f7cfad80-39a2-11eb-9548-e42511af6973.png)
