### PR TITLE
missed a portal parameter in previous pr

### DIFF
--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -15,6 +15,7 @@ const mapStateToProps = (state) => {
     enableSubscriptionManagementScreen: state.portalConfiguration.enableSubscriptionManagementScreen, // eslint-disable-line max-len
     enableSamlConfigurationScreen: state.portalConfiguration.enableSamlConfigurationScreen,
     enableAnalyticsScreen: state.portalConfiguration.enableAnalyticsScreen,
+    enableLmsConfigurationsScreen: state.portalConfiguration.enableLmsConfigurationsScreen,
     enterpriseId: state.portalConfiguration.enterpriseId,
     authentication: state.authentication,
     userAccount: state.userAccount,


### PR DESCRIPTION
I added the expected backend-passed portal configuration flag in my previous [PR](https://github.com/edx/frontend-app-admin-portal/pull/357), but because the backend had not been done yet, I didn't get a chance to test this flag working and thus missed a spot where it needed to be added to one of the jsx files.

This PR adds it to the missing spot. I've verified it works with the backend changes as well.