### PR TITLE
fix: force logout to refresh JWT roles for admin registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4351,7 +4351,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4591,7 +4591,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-imports": {
@@ -5019,7 +5019,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -6591,7 +6591,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -7130,14 +7130,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -8223,7 +8223,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -8950,7 +8950,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -9001,7 +9001,7 @@
     },
     "file-saver": {
       "version": "1.3.8",
-      "resolved": "http://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
     },
     "file-type": {
@@ -9787,7 +9787,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -11043,7 +11043,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -11085,7 +11085,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -11196,7 +11196,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -13636,7 +13636,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -14970,7 +14970,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -14982,7 +14982,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -15046,7 +15046,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true
@@ -15256,7 +15256,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -16424,7 +16424,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -16616,7 +16616,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16679,7 +16679,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -17191,7 +17191,7 @@
     },
     "react-spinners": {
       "version": "0.3.2",
-      "resolved": "http://registry.npmjs.org/react-spinners/-/react-spinners-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.3.2.tgz",
       "integrity": "sha512-SZzc99QqKLq85uGWYvkVeHTEPMEpLwnvQOyY62vNqAT9WWdkGJgHKt4H7Z68ALiWYZGKT5oIclh/cdBX20546w==",
       "requires": {
         "emotion": "^9.1.1",
@@ -17683,7 +17683,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -18279,7 +18279,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -19426,7 +19426,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -19458,7 +19458,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "optional": true,
@@ -19818,7 +19818,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -20427,7 +20427,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/src/components/AdminRegisterPage/index.jsx
+++ b/src/components/AdminRegisterPage/index.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
-import {
-  Container, Row, Col, Alert, MailtoLink,
-} from '@edx/paragon';
+import { Container, Row, Col } from '@edx/paragon';
 
 import LoadingMessage from '../LoadingMessage';
 
-import { getProxyLoginUrl, redirectToProxyLogin } from '../../utils';
+import {
+  getProxyLoginUrl,
+  redirectToProxyLogin,
+  hasEnterpriseAdminRole,
+} from '../../utils';
 import apiClient from '../../data/apiClient';
 
 const AdminRegisterPage = ({ authentication, match }) => {
@@ -15,62 +17,35 @@ const AdminRegisterPage = ({ authentication, match }) => {
 
   useEffect(
     () => {
-      if (!authentication?.username) {
+      if (!authentication.username) {
         // user is not authenticated
         return;
       }
 
-      if (!authentication.roles?.length) {
-        // user is authenticated but doesn't have any JWT roles; force a log out so their
-        // JWT roles gets refreshed. on their next login, the JWT roles will be updated
-        // and we can continue rendering a fallback UI if needed.
+      if (!hasEnterpriseAdminRole(authentication.roles)) {
+        // user is authenticated but doesn't have the `enterprise_admin` JWT role; force a log out so their
+        // JWT roles gets refreshed. on their next login, the JWT roles will be updated.
         const logoutRedirectUrl = getProxyLoginUrl(enterpriseSlug);
         apiClient.logout(logoutRedirectUrl);
       }
     },
-    [authentication?.username, authentication?.roles],
+    [authentication.username, authentication.roles],
   );
 
-  if (authentication?.username) {
-    if (!authentication.roles?.length) {
-      // user is authenticated but does not have any roles, so display a message while
+  if (authentication.username) {
+    if (!hasEnterpriseAdminRole(authentication.roles)) {
+      // user is authenticated but doesn't have the `enterprise_admin` JWT role, so display a message while
       // redirecting the user to the log out page.
       return (
         <Container fluid>
-          <Row className="py-3">
-            <Col>
-              <p>Logging out...</p>
-            </Col>
+          <Row className="admin-registration-logout py-3">
+            <Col>Logging out...</Col>
           </Row>
         </Container>
       );
     }
 
-    if (!authentication.roles?.length) {
-      // user is authenticated but does not have the roles that should be assigned during the
-      // registration flow, likely suggesting the user created an account with a non-matching
-      // email address.
-      return (
-        <Container fluid>
-          <Row className="my-3 justify-content-md-center">
-            <Col xs lg={8} offset={1}>
-              <Alert variant="danger">
-                <p className="mb-0">
-                  We were unable to activate your edX administrator account. Please verify
-                  the email used to register your account. If you run into further issues,
-                  please contact the edX Customer Success team at{' '}
-                  <MailtoLink className="alert-link" to="customersuccess@edx.org">
-                    customersuccess@edx.org
-                  </MailtoLink>.
-                </p>
-              </Alert>
-            </Col>
-          </Row>
-        </Container>
-      );
-    }
-
-    // user is authenticated and has at least one JWT role, so redirect user to
+    // user is authenticated and has the `enterprise_admin` JWT role, so redirect user to
     // account activation page to ensure they verify their email address.
     return (
       <Redirect to={`/${enterpriseSlug}/admin/register/activate`} />

--- a/src/containers/AdminRegisterPage/AdminRegisterPage.test.jsx
+++ b/src/containers/AdminRegisterPage/AdminRegisterPage.test.jsx
@@ -53,15 +53,21 @@ describe('<AdminRegisterPage />', () => {
     expect(global.location.href).toBeTruthy();
   });
 
-  it('displays error alert when user is authenticated but no has JWT roles', () => {
-    const store = mockStore({
-      authentication: {
-        username: 'edx',
-        roles: [],
-      },
+  [
+    { roles: [] },
+    { roles: ['enterprise_learner:*'] },
+  ].forEach(({ roles }) => {
+    it('displays logging out message alert when user is authenticated without "enterprise_admin" JWT role', () => {
+      const store = mockStore({
+        authentication: {
+          username: 'edx',
+          roles,
+        },
+      });
+
+      const wrapper = mount(<AdminRegisterPageWrapper store={store} />);
+      expect(wrapper.find('.admin-registration-logout').exists()).toBeTruthy();
     });
-    const wrapper = mount(<AdminRegisterPageWrapper store={store} />);
-    expect(wrapper.find('Alert').exists()).toBeTruthy();
   });
 
   it('redirects to /admin/register/activate route when user is authenticated and has JWT roles', () => {

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const ENTERPRISE_ADMIN_ROLE_NAME = 'enterprise_admin';

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,7 @@ import isNumeric from 'validator/lib/isNumeric';
 
 import { EMAIL_TEMPLATE_FIELD_MAX_LIMIT, OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT } from './data/constants/emailTemplate';
 import { EMAIL_ADDRESS_TEXT_FORM_DATA, EMAIL_ADDRESS_CSV_FORM_DATA } from './data/constants/addUsers';
+import { ENTERPRISE_ADMIN_ROLE_NAME } from './data/constants';
 import history from './data/history';
 
 const formatTimestamp = ({ timestamp, format = 'MMMM D, YYYY' }) => {
@@ -289,6 +290,11 @@ const redirectToProxyLogin = (enterpriseSlug) => {
   global.location.href = proxyLoginUrl;
 };
 
+const hasEnterpriseAdminRole = roles => roles.some(role => {
+  const roleName = role.split(':')[0];
+  return roleName === ENTERPRISE_ADMIN_ROLE_NAME;
+});
+
 export {
   formatPercentage,
   formatPassedTimestamp,
@@ -313,4 +319,5 @@ export {
   mergeErrors,
   redirectToProxyLogin,
   getProxyLoginUrl,
+  hasEnterpriseAdminRole,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,12 +275,17 @@ const mergeErrors = (object, other) => {
   return mergeWith(object, other, customizer);
 };
 
-const redirectToProxyLogin = (enterpriseSlug) => {
+const getProxyLoginUrl = (enterpriseSlug) => {
   const options = {
     enterprise_slug: enterpriseSlug,
     next: global.location,
   };
   const proxyLoginUrl = `${process.env.LMS_BASE_URL}/enterprise/proxy-login/?${qs.stringify(options)}`;
+  return proxyLoginUrl;
+};
+
+const redirectToProxyLogin = (enterpriseSlug) => {
+  const proxyLoginUrl = getProxyLoginUrl(enterpriseSlug);
   global.location.href = proxyLoginUrl;
 };
 
@@ -307,4 +312,5 @@ export {
   validateEmailAddressesFields,
   mergeErrors,
   redirectToProxyLogin,
+  getProxyLoginUrl,
 };


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-3884

The previous implementation of the logic for admin registration broke down when a user is authenticated but without any JWT roles, causing a danger alert to be rendered.

The issue is that we need their JWT to refresh to bring in the new JWT roles they were assigned through the pending admin user configured in Django Admin. To get around this, we now force a logout with a redirect to the branded logistration page. When they login again, they will have the correct JWT roles added and be able to continue with their admin registration.

Related PR: https://github.com/edx/edx-enterprise/pull/1093
