### PR TITLE
Degreed Configuration Form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3049,6 +3049,129 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.11.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "10.4.8",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.8.tgz",
@@ -3197,6 +3320,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.20",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
+      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -3295,6 +3428,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.11.1",
@@ -6742,6 +6884,12 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {
@@ -13876,6 +14024,12 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
       "optional": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "devDependencies": {
     "@edx/frontend-build": "5.5.1",
     "@intervolga/optimize-cssnano-plugin": "1.0.6",
+    "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "10.4.8",
     "@testing-library/user-event": "12.1.0",
     "codecov": "3.7.0",

--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
@@ -7,8 +7,8 @@ import {
 import { snakeCaseFormData } from '../../utils';
 import LmsApiService from '../../data/services/LmsApiService';
 import StatusAlert from '../StatusAlert';
-import NewRelicService from '../../data/services/NewRelicService';
 import SUBMIT_STATES from '../../data/constants/formSubmissions';
+import { handleErrors, validateLmsConfigForm } from './common';
 
 export const REQUIRED_BLACKBOARD_CONFIG_FIELDS = [
   'blackboardBaseUrl',
@@ -24,13 +24,6 @@ class BlackboardIntegrationConfigForm extends React.Component {
     error: undefined,
   }
 
-  handleErrors = (error) => {
-    const errorMsg = error.message || error.response?.status === 500
-      ? error.message : JSON.stringify(error.response.data);
-    NewRelicService.logAPIErrorResponse(errorMsg);
-    return errorMsg;
-  }
-
   /**
    * Creates a new third party provider configuration, then updates this list with the response.
    * Returns if there is an error.
@@ -44,7 +37,7 @@ class BlackboardIntegrationConfigForm extends React.Component {
       this.setState({ config: response.data, error: undefined });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
   }
 
@@ -56,21 +49,8 @@ class BlackboardIntegrationConfigForm extends React.Component {
       this.setState({ config: response.data, error: undefined });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
-  }
-
-  /**
-   * Validates this form. If the form is invalid, it will return the fields
-   * that were invalid. Otherwise, it will return an empty object.
-   * @param {FormData} formData
-   * @param {[String]} requiredFields
-   */
-  validateBlackboardConfigForm = (formData, requiredFields) => {
-    const invalidFields = requiredFields
-      .filter(field => !formData.get(field))
-      .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
-    return invalidFields;
   }
 
   /**
@@ -79,7 +59,7 @@ class BlackboardIntegrationConfigForm extends React.Component {
    */
   handleSubmit = async (formData, config) => {
     this.setState({ submitState: SUBMIT_STATES.PENDING });
-    const invalidFields = this.validateBlackboardConfigForm(formData, REQUIRED_BLACKBOARD_CONFIG_FIELDS);
+    const invalidFields = validateLmsConfigForm(formData, REQUIRED_BLACKBOARD_CONFIG_FIELDS);
     if (!isEmpty(invalidFields)) {
       this.setState({
         invalidFields: {

--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.test.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import BlackboardIntegrationConfigForm, { REQUIRED_BLACKBOARD_CONFIG_FIELDS } from './BlackboardIntegrationConfigForm';
+import { validateLmsConfigForm } from './common';
 
 const config = {
   active: false,
@@ -19,18 +20,13 @@ const config = {
 
 describe('<BlackboardIntegrationConfigForm />', () => {
   it('fails if any required field is missing', () => {
-    const wrapper = mount(
-      <BlackboardIntegrationConfigForm
-        enterpriseId={config.enterpriseCustomer}
-      />,
-    );
     // Initialize form data
     const formData = new FormData();
     REQUIRED_BLACKBOARD_CONFIG_FIELDS.forEach((requiredField) => formData.append(requiredField, config[requiredField]));
     // Remove form data one key at a time and validate
     REQUIRED_BLACKBOARD_CONFIG_FIELDS.forEach((requiredField) => {
       formData.delete(requiredField);
-      const invalidFields = wrapper.instance().validateBlackboardConfigForm(
+      const invalidFields = validateLmsConfigForm(
         formData,
         REQUIRED_BLACKBOARD_CONFIG_FIELDS,
       );

--- a/src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx
@@ -7,8 +7,8 @@ import {
 import { snakeCaseFormData } from '../../utils';
 import StatusAlert from '../StatusAlert';
 import LmsApiService from '../../data/services/LmsApiService';
-import NewRelicService from '../../data/services/NewRelicService';
 import SUBMIT_STATES from '../../data/constants/formSubmissions';
+import { handleErrors, validateLmsConfigForm } from './common';
 
 export const REQUIRED_CANVAS_CONFIG_FIELDS = [
   'clientId',
@@ -35,7 +35,7 @@ class CanvasIntegrationConfigForm extends React.Component {
       });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
   }
 
@@ -49,20 +49,13 @@ class CanvasIntegrationConfigForm extends React.Component {
       });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
-  }
-
-  validateCanvasConfigForm = (formData, requiredFields) => {
-    const invalidFields = requiredFields
-      .filter(field => !formData.get(field))
-      .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
-    return invalidFields;
   }
 
   handleSubmit = async (formData, config) => {
     await this.setState({ submitState: SUBMIT_STATES.PENDING });
-    const invalidFields = this.validateCanvasConfigForm(formData, REQUIRED_CANVAS_CONFIG_FIELDS);
+    const invalidFields = validateLmsConfigForm(formData, REQUIRED_CANVAS_CONFIG_FIELDS);
     if (!isEmpty(invalidFields)) {
       this.setState({
         invalidFields: {
@@ -89,13 +82,6 @@ class CanvasIntegrationConfigForm extends React.Component {
       return;
     }
     this.setState({ submitState: SUBMIT_STATES.COMPLETE });
-  }
-
-  handleErrors(error) {
-    const errorMsg = error.message || error.response?.status === 500
-      ? error.message : JSON.stringify(error.response.data);
-    NewRelicService.logAPIErrorResponse(errorMsg);
-    return errorMsg;
   }
 
   render() {

--- a/src/components/LmsConfigurations/CanvasIntegrationConfigForm.test.jsx
+++ b/src/components/LmsConfigurations/CanvasIntegrationConfigForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import CanvasIntegrationConfigForm, { REQUIRED_CANVAS_CONFIG_FIELDS } from './CanvasIntegrationConfigForm';
+import { validateLmsConfigForm } from './common';
 
 const config = {
   active: false,
@@ -20,18 +21,13 @@ const config = {
 
 describe('<CanvasIntegrationConfigForm />', () => {
   it('fails if any required field is missing', () => {
-    const wrapper = mount(
-      <CanvasIntegrationConfigForm
-        enterpriseId={config.enterpriseCustomer}
-      />,
-    );
     // Initialize form data
     const formData = new FormData();
     REQUIRED_CANVAS_CONFIG_FIELDS.forEach((requiredField) => formData.append(requiredField, config[requiredField]));
     // Remove form data one key at a time and validate
     REQUIRED_CANVAS_CONFIG_FIELDS.forEach((requiredField) => {
       formData.delete(requiredField);
-      const invalidFields = wrapper.instance().validateCanvasConfigForm(
+      const invalidFields = validateLmsConfigForm(
         formData,
         REQUIRED_CANVAS_CONFIG_FIELDS,
       );

--- a/src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx
@@ -1,0 +1,356 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+import {
+  ValidationFormGroup, Input, StatefulButton, Icon,
+} from '@edx/paragon';
+import { snakeCaseFormData } from '../../utils';
+import LmsApiService from '../../data/services/LmsApiService';
+import StatusAlert from '../StatusAlert';
+import SUBMIT_STATES from '../../data/constants/formSubmissions';
+import { handleErrors, validateLmsConfigForm } from './common';
+
+export const REQUIRED_DEGREED_CONFIG_FIELDS = [
+  'degreedBaseUrl',
+  'degreedUserId',
+  'degreedUserPassword',
+  'secret',
+  'degreedCompanyId',
+  'key',
+];
+
+function configFormReducer(state, action) {
+  switch (action.type) {
+    case 'PENDING': {
+      return { ...state, error: null, submitState: SUBMIT_STATES.PENDING };
+    }
+    case 'ERROR': {
+      return { ...state, error: action.value, submitState: SUBMIT_STATES.ERROR };
+    }
+    case 'INVALID': {
+      return {
+        ...state,
+        submitState: SUBMIT_STATES.ERROR,
+        invalidFields: action.value,
+        error: 'Form could not be submitted as there are fields with invalid values. Please correct them below.',
+      };
+    }
+    case 'COMPLETE': {
+      return {
+        ...state,
+        invalidFields: {},
+        error: null,
+        submitState: SUBMIT_STATES.COMPLETE,
+      };
+    }
+    case 'SET_CONFIG': {
+      return {
+        ...state,
+        config: action.value,
+      };
+    }
+    case 'BASE_SUBMIT': {
+      return {
+        ...state,
+        submitState: SUBMIT_STATES.DEFAULT,
+      };
+    }
+    default: {
+      return { state };
+    }
+  }
+}
+
+function DegreedIntegrationConfigForm({ enterpriseId, config }) {
+  const [state, dispatch] = React.useReducer(
+    configFormReducer,
+    {
+      submitState: SUBMIT_STATES.default,
+      error: null,
+      config: null,
+      invalidFields: {},
+    },
+  );
+  const [active, setActive] = useState(config?.active);
+
+  /**
+   * Creates a new third party provider configuration, then updates this list with the response.
+   * Returns if there is an error.
+   * @param {FormData} formData
+   */
+  const createDegreedConfig = async formData => {
+    const transformedData = snakeCaseFormData(formData);
+    transformedData.append('enterprise_customer', enterpriseId);
+    try {
+      const response = await LmsApiService.postNewDegreedConfig(transformedData);
+      return dispatch({
+        type: 'SET_CONFIG',
+        value: response.data,
+      });
+    } catch (error) {
+      return handleErrors(error);
+    }
+  };
+
+  const updateDegreedConfig = async (formData, configId) => {
+    const transformedData = snakeCaseFormData(formData);
+    transformedData.append('enterprise_customer', enterpriseId);
+    try {
+      const response = await LmsApiService.updateDegreedConfig(transformedData, configId);
+      return dispatch({
+        type: 'SET_CONFIG',
+        value: response.data,
+      });
+    } catch (error) {
+      return handleErrors(error);
+    }
+  };
+
+  /**
+  * attempt to submit the form data and show any error states or invalid fields.
+  * @param {FormData} formData
+  */
+  const handleSubmit = async (formData, existingConfig) => {
+    dispatch({
+      type: 'PENDING',
+    });
+    // validate the form
+    const invalidFields = validateLmsConfigForm(formData, REQUIRED_DEGREED_CONFIG_FIELDS);
+    if (!isEmpty(invalidFields)) {
+      dispatch({
+        type: 'INVALID',
+        value: invalidFields,
+      });
+      return;
+    }
+
+    if (existingConfig) {
+      const err = await updateDegreedConfig(formData, existingConfig.id);
+      if (err) {
+        dispatch({
+          type: 'ERROR',
+          value: err,
+        });
+      } else {
+        dispatch({
+          type: 'COMPLETE',
+        });
+      }
+    } else {
+      // ...or create a new configuration
+      const err = await createDegreedConfig(formData);
+
+      if (err) {
+        dispatch({
+          type: 'ERROR',
+          value: err,
+        });
+      } else {
+        dispatch({
+          type: 'COMPLETE',
+        });
+      }
+    }
+  };
+
+  let errorAlert;
+  if (state.error) {
+    errorAlert = (
+      <div className="form-group is-invalid align-items-left">
+        <StatusAlert
+          alertType="danger"
+          iconClassName="fa fa-times-circle"
+          title="Unable to submit config form:"
+          message={state.error}
+          dismissible
+        />
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        handleSubmit(formData, state.config || config);
+      }}
+      onChange={() => dispatch({ type: 'BASE_SUBMIT' })}
+    >
+      <div className="row">
+        <div className="col col-3 mt-3">
+          {errorAlert}
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-6">
+          <ValidationFormGroup
+            for="active"
+          >
+            <label htmlFor="active">Active</label>
+            <Input
+              type="checkbox"
+              id="active"
+              name="active"
+              className="ml-3"
+              checked={active}
+              onChange={() => setActive(prevState => ({ active: !prevState.active }))}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="degreedCompanyId"
+            invalid={state.invalidFields.degreedCompanyId}
+            invalidMessage="Degreed Organization Code is required."
+            helpText="The organization code provided to you by Degreed."
+          >
+            <label htmlFor="degreedCompanyId">Degreed Organization Code</label>
+            <Input
+              type="text"
+              id="degreedCompanyId"
+              name="degreedCompanyId"
+              defaultValue={config ? config.degreedCompanyId : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="degreedBaseUrl"
+            invalid={state.invalidFields.degreedBaseUrl}
+            invalidMessage="Degreed Instance URL is required."
+            helpText="Your Degreed instance URL. Make sure to include the protocol (ie https/http)"
+          >
+            <label htmlFor="degreedBaseUrl">Degreed Instance URL</label>
+            <Input
+              type="text"
+              id="degreedBaseUrl"
+              name="degreedBaseUrl"
+              defaultValue={config ? config.degreedBaseUrl : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="key"
+            invalid={state.invalidFields.key}
+            invalidMessage="Degreed API Client ID required."
+            helpText="The API Client ID used to make calls to Degreed on behalf of the customer."
+          >
+            <label htmlFor="key">API Client ID</label>
+            <Input
+              type="text"
+              id="key"
+              name="key"
+              defaultValue={config ? config.key : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="secret"
+            invalid={state.invalidFields.secret}
+            invalidMessage="Degreed API Client Secret required."
+            helpText="The API Client Secret used to make calls to Degreed on behalf of the customer."
+          >
+            <label htmlFor="secret">API Client Secret</label>
+            <Input
+              type="password"
+              id="secret"
+              name="secret"
+              defaultValue={config ? config.secret : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="degreedUserId"
+            invalid={state.invalidFields.degreedUserId}
+            invalidMessage="The Degreed User ID is required to access Degreed via Oauth."
+            helpText="The Degreed User ID provided to the content provider by Degreed."
+          >
+            <label htmlFor="degreedUserId">Degreed User ID</label>
+            <Input
+              type="text"
+              id="degreedUserId"
+              name="degreedUserId"
+              defaultValue={config ? config.degreedUserId : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col col-4">
+          <ValidationFormGroup
+            for="degreedUserPassword"
+            invalid={state.invalidFields.degreedUserPassword}
+            invalidMessage="The Degreed User Password is required to access Degreed via Oauth."
+            helpText="The Degreed User Password provided to the content provider by Degreed."
+          >
+            <label htmlFor="degreedUserPassword">Degreed User Password</label>
+            <Input
+              type="password"
+              id="degreedUserPassword"
+              name="degreedUserPassword"
+              defaultValue={config ? config.degreedUserPassword : null}
+            />
+          </ValidationFormGroup>
+        </div>
+      </div>
+
+      <div className="row">
+        <div className="col col-2">
+          <StatefulButton
+            state={state.submitState}
+            type="submit"
+            id="submitButton"
+            labels={{
+              default: 'Submit',
+              pending: 'Saving...',
+              complete: 'Complete',
+              error: 'Error',
+            }}
+            icons={{
+              default: <Icon className="fa fa-download" />,
+              pending: <Icon className="fa fa-spinner fa-spin" />,
+              complete: <Icon className="fa fa-check" />,
+              error: <Icon className="fa fa-times" />,
+            }}
+            disabledStates={[SUBMIT_STATES.PENDING]}
+            variant="primary"
+            className="ml-3 col"
+          />
+        </div>
+      </div>
+    </form>
+  );
+}
+
+DegreedIntegrationConfigForm.defaultProps = {
+  config: null,
+};
+
+DegreedIntegrationConfigForm.propTypes = {
+  enterpriseId: PropTypes.string.isRequired,
+  config: PropTypes.shape({
+    active: PropTypes.bool,
+    degreedBaseUrl: PropTypes.string,
+    degreedCompanyId: PropTypes.string,
+    degreedUserId: PropTypes.string,
+    degreedUserPassword: PropTypes.string,
+    key: PropTypes.string,
+    secret: PropTypes.string,
+  }),
+};
+
+export default DegreedIntegrationConfigForm;

--- a/src/components/LmsConfigurations/DegreedIntegrationConfigForm.test.jsx
+++ b/src/components/LmsConfigurations/DegreedIntegrationConfigForm.test.jsx
@@ -1,0 +1,133 @@
+import {
+  render, fireEvent, screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import snakeCase from 'lodash/snakeCase';
+import DegreedIntegrationConfigForm from './DegreedIntegrationConfigForm';
+import LmsApiService from '../../data/services/LmsApiService';
+
+jest.mock('../../data/services/LmsApiService', () => ({
+  postNewDegreedConfig: jest.fn(),
+  updateDegreedConfig: jest.fn(),
+}));
+
+const enterpriseId = 'test-enterprise';
+
+describe('<DegreedIntegrationConfigForm />', () => {
+  test('renders Degreed Config Form', () => {
+    render(<DegreedIntegrationConfigForm enterpriseId={enterpriseId} />);
+    // Verify all expected fields are present.
+    screen.getByLabelText('Active');
+    screen.getByLabelText('Degreed User ID');
+    screen.getByLabelText('Degreed User Password');
+    screen.getByLabelText('Degreed Instance URL');
+    screen.getByLabelText('Degreed Organization Code');
+    screen.getByLabelText('API Client ID');
+    screen.getByLabelText('API Client Secret');
+  });
+
+  test('fills in fields when config is passed in as argument/prop.', () => {
+    const initialConfig = {
+      active: true,
+      degreedUserId: 'initial_id',
+      degreedUserPassword: 'initial_pass',
+      degreedBaseUrl: 'initial_url',
+      degreedCompanyId: 'initial_org',
+      key: 'initial_key',
+      secret: 'initial_secret',
+    };
+    render(<DegreedIntegrationConfigForm enterpriseId={enterpriseId} config={initialConfig} />);
+    expect(screen.getByLabelText('Active')).toBeChecked();
+    expect(screen.getByLabelText('Degreed User ID')).toHaveValue('initial_id');
+    expect(screen.getByLabelText('Degreed User Password')).toHaveValue('initial_pass');
+    expect(screen.getByLabelText('Degreed Instance URL')).toHaveValue('initial_url');
+    expect(screen.getByLabelText('Degreed Organization Code')).toHaveValue('initial_org');
+    expect(screen.getByLabelText('API Client ID')).toHaveValue('initial_key');
+    expect(screen.getByLabelText('API Client Secret')).toHaveValue('initial_secret');
+  });
+
+  test('required fields show as invalid when not filled in', () => {
+    render(<DegreedIntegrationConfigForm enterpriseId={enterpriseId} />);
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(screen.getByLabelText('Degreed User ID')).toHaveClass('is-invalid');
+    expect(screen.getByLabelText('Degreed User Password')).toHaveClass('is-invalid');
+    expect(screen.getByLabelText('Degreed Instance URL')).toHaveClass('is-invalid');
+    expect(screen.getByLabelText('Degreed Organization Code')).toHaveClass('is-invalid');
+    expect(screen.getByLabelText('API Client ID')).toHaveClass('is-invalid');
+    expect(screen.getByLabelText('API Client Secret')).toHaveClass('is-invalid');
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Form could not be submitted as there are fields with invalid values. '
+      + 'Please correct them below.',
+    );
+  });
+
+  test('submit calls postNewDegreedConfig when config is not present', () => {
+    const expectedFormData = {
+      degreed_user_id: 'testuserid',
+      degreed_user_password: 'testpass',
+      degreed_base_url: 'testinstance',
+      degreed_company_id: 'testorg',
+      key: 'testclientid',
+      secret: 'testsecret',
+      enterprise_customer: enterpriseId,
+    };
+
+    render(<DegreedIntegrationConfigForm enterpriseId={enterpriseId} />);
+    fireEvent.change(screen.getByLabelText('Degreed User ID'), {
+      target: { value: 'testuserid' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed User Password'), {
+      target: { value: 'testpass' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Instance URL'), {
+      target: { value: 'testinstance' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Organization Code'), {
+      target: { value: 'testorg' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'testclientid' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'testsecret' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    const postedFormData = Array.from(LmsApiService.postNewDegreedConfig.mock.calls[0][0].entries())
+      .reduce((acc, f) => ({ ...acc, [f[0]]: f[1] }), {});
+
+    expect(postedFormData).toMatchObject(expectedFormData);
+  });
+
+  test('submit calls updateDegreedConfig when config is not present', () => {
+    const initialConfig = {
+      degreedUserId: 'testuserid',
+      degreedUserPassword: 'testpass',
+      degreedBaseUrl: 'testinstance',
+      degreedCompanyId: 'testorg',
+      key: 'testclientid',
+      secret: 'testsecret',
+    };
+
+    render(<DegreedIntegrationConfigForm enterpriseId={enterpriseId} config={initialConfig} />);
+    fireEvent.change(screen.getByLabelText('Degreed User ID'), {
+      target: { value: 'changedUserId' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    const updatedConfig = {};
+    Object.entries(initialConfig)
+      .forEach(([key, value]) => {
+        updatedConfig[snakeCase(key)] = value;
+      });
+    updatedConfig.degreed_user_id = 'changedUserId';
+    updatedConfig.enterprise_customer = enterpriseId;
+
+    const postedFormData = Array.from(LmsApiService.updateDegreedConfig.mock.calls[0][0].entries())
+      .reduce((acc, f) => ({ ...acc, [f[0]]: f[1] }), {});
+
+    expect(postedFormData).toMatchObject(updatedConfig);
+  });
+});

--- a/src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx
@@ -7,8 +7,8 @@ import {
 import { snakeCaseFormData } from '../../utils';
 import LmsApiService from '../../data/services/LmsApiService';
 import StatusAlert from '../StatusAlert';
-import NewRelicService from '../../data/services/NewRelicService';
 import SUBMIT_STATES from '../../data/constants/formSubmissions';
+import { handleErrors, validateLmsConfigForm } from './common';
 
 export const REQUIRED_MOODLE_CONFIG_FIELDS = [
   'moodleBaseUrl',
@@ -21,13 +21,6 @@ class MoodleIntegrationConfigForm extends React.Component {
     submitState: SUBMIT_STATES.DEFAULT,
     active: this.props.config?.active,
     error: null,
-  }
-
-  handleErrors = (error) => {
-    const errorMsg = error.message || error.response?.status === 500
-      ? error.message : JSON.stringify(error.response.data);
-    NewRelicService.logAPIErrorResponse(errorMsg);
-    return errorMsg;
   }
 
   /**
@@ -43,7 +36,7 @@ class MoodleIntegrationConfigForm extends React.Component {
       this.setState({ config: response.data });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
   }
 
@@ -55,21 +48,8 @@ class MoodleIntegrationConfigForm extends React.Component {
       this.setState({ config: response.data });
       return undefined;
     } catch (error) {
-      return this.handleErrors(error);
+      return handleErrors(error);
     }
-  }
-
-  /**
-   * Validates this form. If the form is invalid, it will return the fields
-   * that were invalid. Otherwise, it will return an empty object.
-   * @param {FormData} formData
-   * @param {[String]} requiredFields
-   */
-  validateMoodleConfigForm = (formData, requiredFields) => {
-    const invalidFields = requiredFields
-      .filter(field => !formData.get(field))
-      .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
-    return invalidFields;
   }
 
   /**
@@ -89,7 +69,7 @@ class MoodleIntegrationConfigForm extends React.Component {
       requiredFields.push('duplicateCreds');
     }
     // validate the form
-    const invalidFields = this.validateMoodleConfigForm(formData, requiredFields);
+    const invalidFields = validateLmsConfigForm(formData, requiredFields);
     if (!isEmpty(invalidFields)) {
       this.setState({
         invalidFields: {

--- a/src/components/LmsConfigurations/MoodleIntegrationConfigForm.test.jsx
+++ b/src/components/LmsConfigurations/MoodleIntegrationConfigForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import MoodleIntegrationConfigForm, { REQUIRED_MOODLE_CONFIG_FIELDS } from './MoodleIntegrationConfigForm';
+import { validateLmsConfigForm } from './common';
 
 const formData = new FormData();
 REQUIRED_MOODLE_CONFIG_FIELDS.forEach(field => formData.append(field, 'testdata'));
@@ -8,8 +9,7 @@ REQUIRED_MOODLE_CONFIG_FIELDS.forEach(field => formData.append(field, 'testdata'
 describe('<MoodleIntegrationConfigForm />', () => {
   it('validation fails if required fields missing', () => {
     const invalidFormData = new FormData();
-    const wrapper = shallow(<MoodleIntegrationConfigForm enterpriseId="testing123" />);
-    const invalidFields = wrapper.instance().validateMoodleConfigForm(
+    const invalidFields = validateLmsConfigForm(
       invalidFormData,
       REQUIRED_MOODLE_CONFIG_FIELDS,
     );

--- a/src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.test.jsx
+++ b/src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.test.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
-import SuccessFactorsConfigForm, { REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS } from './SuccessFactorsIntegrationConfigForm';
+import { mount } from 'enzyme';
+import SuccessFactorsIntegrationConfigForm, { REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS } from './SuccessFactorsIntegrationConfigForm';
+import { validateLmsConfigForm } from './common';
 
 const formData = new FormData();
 REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS.forEach(field => formData.append(field, 'testdata'));
 
-describe('<SuccessFactorsConfigForm />', () => {
+describe('<SuccessFactorsIntegrationConfigForm />', () => {
   it('validation fails if required fields missing', () => {
     const invalidFormData = new FormData();
-    const wrapper = shallow(<SuccessFactorsConfigForm enterpriseId="testing123" />);
-    const invalidFields = wrapper.instance().validateSuccessFactorsConfigForm(
+    const invalidFields = validateLmsConfigForm(
       invalidFormData,
       REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS,
     );
@@ -18,7 +18,7 @@ describe('<SuccessFactorsConfigForm />', () => {
 
   it('submit calls createSuccessFactorsConfig when config is not present', () => {
     const wrapper = mount((
-      <SuccessFactorsConfigForm enterpriseId="testing123" />
+      <SuccessFactorsIntegrationConfigForm enterpriseId="testing123" />
     ));
     const spyCreate = jest.spyOn(wrapper.instance(), 'createSuccessFactorsConfig');
     wrapper.instance().handleSubmit(formData);
@@ -31,7 +31,7 @@ describe('<SuccessFactorsConfigForm />', () => {
       sapsfBaseUrl: 'testing.com',
     };
     const wrapper = mount((
-      <SuccessFactorsConfigForm enterpriseId="testing123" config={config} />
+      <SuccessFactorsIntegrationConfigForm enterpriseId="testing123" config={config} />
     ));
     const spyUpdate = jest.spyOn(wrapper.instance(), 'updateSuccessFactorsConfig');
     wrapper.instance().handleSubmit(formData, config);
@@ -39,7 +39,7 @@ describe('<SuccessFactorsConfigForm />', () => {
   });
 
   it('show StatusAlert on errors', () => {
-    const wrapper = mount((<SuccessFactorsConfigForm enterpriseId="testing123" />));
+    const wrapper = mount((<SuccessFactorsIntegrationConfigForm enterpriseId="testing123" />));
     wrapper.setState({ error: 'error occurred.' });
     expect(wrapper.find('StatusAlert').first().props().message).toEqual('error occurred.');
   });

--- a/src/components/LmsConfigurations/common.jsx
+++ b/src/components/LmsConfigurations/common.jsx
@@ -1,0 +1,21 @@
+import NewRelicService from '../../data/services/NewRelicService';
+
+export const handleErrors = (error) => {
+  const errorMsg = error.message || error.response?.status === 500
+    ? error.message : JSON.stringify(error.response.data);
+  NewRelicService.logAPIErrorResponse(errorMsg);
+  return errorMsg;
+};
+
+/**
+   * Validates this form. If the form is invalid, it will return the fields
+   * that were invalid. Otherwise, it will return an empty object.
+   * @param {FormData} formData
+   * @param {[String]} requiredFields
+   */
+export const validateLmsConfigForm = (formData, requiredFields) => {
+  const invalidFields = requiredFields
+    .filter(field => !formData.get(field))
+    .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
+  return invalidFields;
+};

--- a/src/components/LmsConfigurations/index.jsx
+++ b/src/components/LmsConfigurations/index.jsx
@@ -5,6 +5,7 @@ import MoodleIntegrationConfigForm from './MoodleIntegrationConfigForm';
 import CanvasIntegrationConfigForm from './CanvasIntegrationConfigForm';
 import BlackboardIntegrationConfigForm from './BlackboardIntegrationConfigForm';
 import SuccessFactorsIntegrationConfigForm from './SuccessFactorsIntegrationConfigForm';
+import DegreedIntegrationConfigForm from './DegreedIntegrationConfigForm';
 import LmsApiService from '../../data/services/LmsApiService';
 import { camelCaseObject } from '../../utils';
 import LoadingMessage from '../LoadingMessage';
@@ -16,6 +17,7 @@ class LmsConfigurations extends React.Component {
     canvasConfig: null,
     blackboardConfig: null,
     sapsfConfig: null,
+    degreedConfig: null,
     error: null,
     loading: true,
   };
@@ -26,6 +28,7 @@ class LmsConfigurations extends React.Component {
       LmsApiService.fetchCanvasConfig(this.props.enterpriseId),
       LmsApiService.fetchBlackboardConfig(this.props.enterpriseId),
       LmsApiService.fetchSuccessFactorsConfig(this.props.enterpriseId),
+      LmsApiService.fetchDegreedConfig(this.props.enterpriseId),
     ]).then((responses) => {
       if (responses.some(response => response.reason?.request.status === 400
           || response.reason?.request.status > 404)) {
@@ -49,6 +52,8 @@ class LmsConfigurations extends React.Component {
             ? responses[2].value.data.results[0] : null,
           sapsfConfig: responses[3].status === 'fulfilled'
             ? responses[3].value.data.results[0] : null,
+          degreedConfig: responses[4].status === 'fulfilled'
+            ? responses[4].value.data.results[0] : null,
           loading: false,
         });
       }
@@ -57,7 +62,7 @@ class LmsConfigurations extends React.Component {
 
   render() {
     const {
-      canvasConfig, moodleConfig, blackboardConfig, sapsfConfig, error, loading,
+      canvasConfig, moodleConfig, blackboardConfig, sapsfConfig, degreedConfig, error, loading,
     } = this.state;
     if (loading) {
       return <LoadingMessage className="overview" />;
@@ -102,6 +107,15 @@ class LmsConfigurations extends React.Component {
         />
       );
     }
+
+    if (degreedConfig) {
+      return (
+        <DegreedIntegrationConfigForm
+          config={camelCaseObject(degreedConfig)}
+          enterpriseId={this.props.enterpriseId}
+        />
+      );
+    }
     return (
       <>
         <div
@@ -115,6 +129,11 @@ class LmsConfigurations extends React.Component {
           >
             <MoodleIntegrationConfigForm enterpriseId={this.props.enterpriseId} />
           </Collapsible>
+        </div>
+        <div
+          key="successfactors-form-link"
+          className="mb-3"
+        >
           <Collapsible
             styling="card"
             className="shadow"
@@ -142,9 +161,21 @@ class LmsConfigurations extends React.Component {
           <Collapsible
             styling="card"
             className="shadow"
-            title="Canvas"
+            title="Blackboard"
           >
             <BlackboardIntegrationConfigForm enterpriseId={this.props.enterpriseId} />
+          </Collapsible>
+        </div>
+        <div
+          key="degreed-form-link"
+          className="mb-3"
+        >
+          <Collapsible
+            styling="card"
+            className="shadow"
+            title="Degreed"
+          >
+            <DegreedIntegrationConfigForm enterpriseId={this.props.enterpriseId} />
           </Collapsible>
         </div>
       </>

--- a/src/components/LmsConfigurations/index.test.jsx
+++ b/src/components/LmsConfigurations/index.test.jsx
@@ -6,6 +6,7 @@ import { REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS } from './SuccessFactorsIntegrati
 import LmsConfigurations from './index';
 import LmsApiService from '../../data/services/LmsApiService';
 import { REQUIRED_BLACKBOARD_CONFIG_FIELDS } from './BlackboardIntegrationConfigForm';
+import { REQUIRED_DEGREED_CONFIG_FIELDS } from './DegreedIntegrationConfigForm';
 
 jest.mock('./../../data/services/LmsApiService');
 
@@ -52,6 +53,16 @@ const badBlackboardResponse = {
   request: { status: 400, statusText: 'Bad Request' },
 };
 
+const degreedResponse = {
+  data: { results: [{}] },
+};
+const notFoundDegreedResponse = {
+  request: { status: 404, statusText: 'Not Found' },
+};
+const badDegreedResponse = {
+  request: { status: 400, statusText: 'Bad Request' },
+};
+
 REQUIRED_MOODLE_CONFIG_FIELDS.forEach((field) => {
   moodleResponse.data.results[0][field] = 'testdata';
 });
@@ -68,14 +79,19 @@ REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS.forEach((field) => {
   successFactorsResponse.data.results[0][field] = 'testdata';
 });
 
+REQUIRED_DEGREED_CONFIG_FIELDS.forEach((field) => {
+  degreedResponse.data.results[0][field] = 'testdata';
+});
+
 const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
 
 describe('<LmsConfigurations /> ', () => {
-  it('get list of forms when all configs return 404s', async () => {
+  it('gets list of forms when all configs return 404s', async () => {
     LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
     LmsApiService.fetchBlackboardConfig.mockRejectedValue(notFoundBlackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -83,13 +99,14 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('ErrorPage').length).toBe(0);
     expect(wrapper.find('CollapsibleAdvanced').length).toBeGreaterThan(0);
   });
-  it('get the Moodle LMS configuration when present', async () => {
+  it('gets the Moodle LMS configuration when present', async () => {
     LmsApiService.fetchMoodleConfig.mockResolvedValue(moodleResponse);
 
     // Mock the fetch of the other configs to 404, not found
     LmsApiService.fetchBlackboardConfig.mockRejectedValue(notFoundBlackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -98,13 +115,14 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('MoodleIntegrationConfigForm').props().config).toEqual(wrapper.state().moodleConfig);
   });
 
-  it('get the Blackboard LMS configuration when present', async () => {
+  it('gets the Blackboard LMS configuration when present', async () => {
     LmsApiService.fetchBlackboardConfig.mockResolvedValue(blackboardResponse);
 
     // Mock the fetch of the other configs to 404, not found
     LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -113,11 +131,12 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('BlackboardIntegrationConfigForm').props().config).toEqual(wrapper.state().blackboardConfig);
   });
 
-  it('get the Canvas LMS configuration when present', async () => {
+  it('gets the Canvas LMS configuration when present', async () => {
     LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
     LmsApiService.fetchBlackboardConfig.mockRejectedValue(notFoundBlackboardResponse);
     LmsApiService.fetchCanvasConfig.mockResolvedValue(canvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -126,17 +145,31 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('CanvasIntegrationConfigForm').props().config).toEqual(wrapper.state().canvasConfig);
   });
 
-  it('get the Success Factors LMS configuration when present', async () => {
+  it('gets the Success Factors LMS configuration when present', async () => {
     LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
     LmsApiService.fetchBlackboardConfig.mockRejectedValue(notFoundBlackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockResolvedValue(successFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
     wrapper.update();
     expect(wrapper.state().sapsfConfig).toEqual(successFactorsResponse.data.results[0]);
     expect(wrapper.find('SuccessFactorsIntegrationConfigForm').props().config).toEqual(wrapper.state().sapsfConfig);
+  });
+
+  it('gets the Degreed LMS configuration when present', async () => {
+    LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
+    LmsApiService.fetchBlackboardConfig.mockRejectedValue(notFoundBlackboardResponse);
+    LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
+    LmsApiService.fetchSuccessFactorsConfig.mockResolvedValue(successFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockResolvedValue(degreedResponse);
+
+    const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
+    await waitForAsync();
+    wrapper.update();
+    expect(wrapper.state().degreedConfig).toEqual(degreedResponse.data.results[0]);
   });
 
   it('return Error Page when the Moodle LMS fetch request fails with error (not 404)', async () => {
@@ -147,6 +180,7 @@ describe('<LmsConfigurations /> ', () => {
     LmsApiService.fetchBlackboardConfig.mockResolvedValue(blackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -158,6 +192,7 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('SuccessFactorsIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('CanvasIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('BlackboardIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('DegreedIntegrationConfigForm').length).toBe(0);
   });
 
   it('return Error Page when Blackboard LMS fetch request fails with an error (not 404)', async () => {
@@ -168,6 +203,7 @@ describe('<LmsConfigurations /> ', () => {
     LmsApiService.fetchMoodleConfig.mockResolvedValue(blackboardResponse);
     LmsApiService.fetchCanvasConfig.mockResolvedValue(canvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -179,6 +215,7 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('SuccessFactorsIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('CanvasIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('BlackboardIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('DegreedIntegrationConfigForm').length).toBe(0);
   });
 
   it('return Error Page when the Canvas LMS fetch request fails with error (not 404)', async () => {
@@ -186,6 +223,7 @@ describe('<LmsConfigurations /> ', () => {
     LmsApiService.fetchBlackboardConfig.mockResolvedValue(blackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(badCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(notFoundSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -197,6 +235,7 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('SuccessFactorsIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('CanvasIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('BlackboardIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('DegreedIntegrationConfigForm').length).toBe(0);
   });
 
   it('return Error Page when the Success Factors LMS fetch request fails with error (not 404)', async () => {
@@ -204,6 +243,7 @@ describe('<LmsConfigurations /> ', () => {
     LmsApiService.fetchBlackboardConfig.mockResolvedValue(blackboardResponse);
     LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
     LmsApiService.fetchSuccessFactorsConfig.mockRejectedValue(badSuccessFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(notFoundDegreedResponse);
 
     const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
     await waitForAsync();
@@ -215,5 +255,26 @@ describe('<LmsConfigurations /> ', () => {
     expect(wrapper.find('SuccessFactorsIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('CanvasIntegrationConfigForm').length).toBe(0);
     expect(wrapper.find('BlackboardIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('DegreedIntegrationConfigForm').length).toBe(0);
+  });
+
+  it('return Error Page when the Degreed LMS fetch request fails with error (not 404)', async () => {
+    LmsApiService.fetchMoodleConfig.mockRejectedValue(notFoundMoodleResponse);
+    LmsApiService.fetchBlackboardConfig.mockResolvedValue(blackboardResponse);
+    LmsApiService.fetchCanvasConfig.mockRejectedValue(notFoundCanvasResponse);
+    LmsApiService.fetchSuccessFactorsConfig.mockResolvedValue(successFactorsResponse);
+    LmsApiService.fetchDegreedConfig.mockRejectedValue(badDegreedResponse);
+
+    const wrapper = mount(<LmsConfigurations enterpriseId="testEnterpriseId" />);
+    await waitForAsync();
+    wrapper.update();
+
+    expect(wrapper.state().degreedConfig).toBeFalsy();
+    expect(wrapper.find('ErrorPage').length).toBe(1);
+    expect(wrapper.find('MoodleIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('SuccessFactorsIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('CanvasIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('BlackboardIntegrationConfigForm').length).toBe(0);
+    expect(wrapper.find('DegreedIntegrationConfigForm').length).toBe(0);
   });
 });

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -163,6 +163,18 @@ class LmsApiService {
   static updateSuccessFactorsConfig(formData, configId) {
     return apiClient.put(`${LmsApiService.lmsIntegrationUrl}/sap_success_factors/configuration/${configId}/`, formData, 'json');
   }
+
+  static fetchDegreedConfig(uuid) {
+    return apiClient.get(`${LmsApiService.lmsIntegrationUrl}/degreed/configuration/?enterprise_customer=${uuid}`);
+  }
+
+  static postNewDegreedConfig(formData) {
+    return apiClient.post(`${LmsApiService.lmsIntegrationUrl}/degreed/configuration/`, formData, 'json');
+  }
+
+  static updateDegreedConfig(formData, configId) {
+    return apiClient.put(`${LmsApiService.lmsIntegrationUrl}/degreed/configuration/${configId}/`, formData, 'json');
+  }
 }
 
 export default LmsApiService;


### PR DESCRIPTION
This adds the new form for Degreed Customer Configuration.

This also attempts to set some precedent in this repo with the following:
- Moving the error alert to the top of the form and triggering focus on it to align with Accessibility guidelines.
- Uses React Testing Library on every test on the form component
- Instantiates the form component as a functional component and utilizes `useState` and `useReducer`

This also moves 2 functions we were word for word reusing across LmsConfiguration forms into a common.jsx file (those are `handleErrors` and `validate[LMSName]ConfigForm` (which has been renamed `validateLmsConfigForm`))

Oh it also fixes 2 visual bugs:
- Blackboard was labeled as Canvas
- Success Factors wasn't properly wrapped in a div.

What this does ***not*** do:
- Update existing LMS Configuration forms to this format [there is a Jira ticket for this](https://openedx.atlassian.net/browse/ENT-3908)
- Does not update the testing in the index file to use this format (also should covered by the same Jira ticket)

It should be fully ready for review.