### PR TITLE
ENT-3883 Disable bulk enrollment when the subscription is invalid

### DIFF
--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -163,7 +163,7 @@ class EnterpriseApp extends React.Component {
                       render={routeProps => <RequestCodesPage {...routeProps} />}
                     />,
                   ]}
-                  {features.BULK_ENROLLMENT
+                  {(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen)
                     && (
                     <Route
                       key="bulk-enrollment"

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -99,7 +99,7 @@ class Sidebar extends React.Component {
         title: 'Bulk Enrollment',
         to: `${baseUrl}/admin/bulkenrollment`,
         icon: faBookOpen,
-        hidden: !features.BULK_ENROLLMENT,
+        hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),
       },
       {
         title: 'LMS Integration Configuration',


### PR DESCRIPTION
Added flags so that Bulk Enrollment depends on same subscription management screen, with the idea being that if your enterprise can manage subscriptions it should be able to enroll learners.