### PR TITLE
minor UI/bug fixes for LMS config forms

### DIFF
--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
@@ -71,7 +71,6 @@ class BlackboardIntegrationConfigForm extends React.Component {
     }
 
     formData.append('enterprise_customer', this.props.enterpriseId);
-    formData.set('active', this.state.active);
 
     let err;
     if (config) {

--- a/src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx
@@ -54,7 +54,7 @@ class CanvasIntegrationConfigForm extends React.Component {
   }
 
   handleSubmit = async (formData, config) => {
-    await this.setState({ submitState: SUBMIT_STATES.PENDING });
+    await this.setState({ submitState: SUBMIT_STATES.PENDING, error: null, invalidFields: {} });
     const invalidFields = validateLmsConfigForm(formData, REQUIRED_CANVAS_CONFIG_FIELDS);
     if (!isEmpty(invalidFields)) {
       this.setState({
@@ -67,7 +67,6 @@ class CanvasIntegrationConfigForm extends React.Component {
     }
 
     formData.append('enterprise_customer', this.props.enterpriseId);
-    formData.set('active', this.state.active);
     let err;
     if (config) {
       err = await this.updateCanvasConfig(formData, config.id);
@@ -116,6 +115,23 @@ class CanvasIntegrationConfigForm extends React.Component {
         }}
         onChange={() => this.setState({ submitState: SUBMIT_STATES.DEFAULT })}
       >
+        <div className="row">
+          <div className="col col-6">
+            <ValidationFormGroup
+              for="active"
+            >
+              <label htmlFor="active">Active</label>
+              <Input
+                type="checkbox"
+                id="active"
+                name="active"
+                className="ml-3"
+                checked={active}
+                onChange={() => this.setState(prevState => ({ active: !prevState.active }))}
+              />
+            </ValidationFormGroup>
+          </div>
+        </div>
         <div className="row">
           <div className="col col-6">
             <ValidationFormGroup
@@ -188,23 +204,6 @@ class CanvasIntegrationConfigForm extends React.Component {
                 className="ml-3"
                 defaultValue={config ? config.canvasBaseUrl : null}
                 onChange={() => this.setState(prevState => ({ canvasBaseUrl: !prevState.canvasBaseUrl }))}
-              />
-            </ValidationFormGroup>
-          </div>
-        </div>
-        <div className="row">
-          <div className="col col-6">
-            <ValidationFormGroup
-              for="active"
-            >
-              <label htmlFor="active">Active</label>
-              <Input
-                type="checkbox"
-                id="active"
-                name="active"
-                className="ml-3"
-                checked={active}
-                onChange={() => this.setState(prevState => ({ active: !prevState.active }))}
               />
             </ValidationFormGroup>
           </div>

--- a/src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx
@@ -194,7 +194,7 @@ function DegreedIntegrationConfigForm({ enterpriseId, config }) {
               name="active"
               className="ml-3"
               checked={active}
-              onChange={() => setActive(prevState => ({ active: !prevState.active }))}
+              onChange={() => setActive(!active)}
             />
           </ValidationFormGroup>
         </div>

--- a/src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx
@@ -57,7 +57,7 @@ class MoodleIntegrationConfigForm extends React.Component {
    * @param {FormData} formData
    */
   handleSubmit = async (formData, config) => {
-    this.setState({ submitState: SUBMIT_STATES.PENDING, error: null });
+    this.setState({ submitState: SUBMIT_STATES.PENDING, error: null, invalidFields: {} });
     let requiredFields = [];
     requiredFields = [...REQUIRED_MOODLE_CONFIG_FIELDS];
     if (!formData.get('token')) {

--- a/src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx
@@ -60,7 +60,7 @@ class SuccessFactorsIntegrationConfigForm extends React.Component {
    * @param {FormData} formData
    */
   handleSubmit = async (formData, config) => {
-    this.setState({ submitState: SUBMIT_STATES.PENDING, error: null });
+    this.setState({ submitState: SUBMIT_STATES.PENDING, error: null, invalidFields: {} });
     const requiredFields = [...REQUIRED_SUCCESS_FACTOR_CONFIG_FIELDS];
 
     // validate the form

--- a/src/components/LmsConfigurations/common.jsx
+++ b/src/components/LmsConfigurations/common.jsx
@@ -3,7 +3,7 @@ import NewRelicService from '../../data/services/NewRelicService';
 export const handleErrors = (error) => {
   const errorMsg = error.message || error.response?.status === 500
     ? error.message : JSON.stringify(error.response.data);
-  NewRelicService.logAPIErrorResponse(errorMsg);
+  NewRelicService.logAPIErrorResponse(error);
   return errorMsg;
 };
 

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -137,7 +137,7 @@ class LmsApiService {
   }
 
   static updateCanvasConfig(formData, id) {
-    return apiClient.patch(`${LmsApiService.lmsIntegrationUrl}/canvas/configuration/${id}/`, formData, 'json');
+    return apiClient.put(`${LmsApiService.lmsIntegrationUrl}/canvas/configuration/${id}/`, formData, 'json');
   }
 
   static fetchBlackboardConfig(uuid) {


### PR DESCRIPTION
This just cleans up some graphical issues and backend bugs:
- fixed active flag in some of the config forms was being sent as "undefined" which was causing an error in backend validation (field is boolean and does not support undefined)
- fixed error state not clearing after resubmission.
- moved Active box to top for Canvas form for ~ consistency ~
- used put instead of patch, because form value was being interpreted as no change instead of "false"
- Fixed the error format of the error we send to NewRelic as it wasn't matching the actual NR method logic.