### PR TITLE
Allow access to LMS Configuration screen without feature flag

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -161,7 +161,7 @@ module.exports = merge(commonConfig, {
         SUPPORT: true,
         SAML_CONFIGURATION: true,
         CODE_VISIBILITY: false,
-        EXTERNAL_LMS_CONFIGURATION: false,
+        EXTERNAL_LMS_CONFIGURATION: true,
       },
     }),
     new HtmlWebpackNewRelicPlugin({


### PR DESCRIPTION
This is for ENT-3418.

This now enables the LMS Configuration screen such that [**if enabled in LMS admin**] an enterprise customer can now access the sidebar item without the feature flag query string.