### PR TITLE
fix: remove client-side filtering of `isActive` subscription plans as API now only returns active plans

### DIFF
--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -30,10 +30,6 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
     LicenseManagerApiService.fetchSubscriptions({ enterprise_customer_uuid: enterpriseId, page })
       .then((response) => {
         const { data: subscriptionsData } = camelCaseObject(response);
-        const subscriptionsList = subscriptionsData?.results || [];
-        subscriptionsData.results = subscriptionsList.filter((
-          subscription => subscription.isActive
-        ));
         setSubscriptions(subscriptionsData);
       })
       .catch((err) => {

--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -29,12 +29,12 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
   useMemo((page = 1) => {
     LicenseManagerApiService.fetchSubscriptions({ enterprise_customer_uuid: enterpriseId, page })
       .then((response) => {
-        const { data: subscriptionsData } = response;
+        const { data: subscriptionsData } = camelCaseObject(response);
         const subscriptionsList = subscriptionsData?.results || [];
         subscriptionsData.results = subscriptionsList.filter((
-          subscription => subscription.is_active
+          subscription => subscription.isActive
         ));
-        setSubscriptions(camelCaseObject(subscriptionsData));
+        setSubscriptions(subscriptionsData);
       })
       .catch((err) => {
         NewRelicService.logAPIErrorResponse(err);


### PR DESCRIPTION
The SubscriptionViewSet that returns subscriptions to admins did not previously filter for `is_active=True`, so we had to filter for active plans client-side.

Despite this, we were referencing the total count of plans returned by the API rather than the filtered count. This is causing a bug on Subscriptions page where we'll show the "Back to subscriptions" button when the Enterprise has 2 subscription plans, one of which is inactive.

Related: https://github.com/edx/license-manager/pull/177