### PR TITLE
fix: attempting to fix build error on deploy

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -77,6 +77,7 @@ module.exports = merge(commonConfig, {
           // Caches result of loader to the filesystem. Future builds will attempt to read from the
           // cache to avoid needing to run the expensive recompilation process on each run.
           cacheDirectory: true,
+          presets: ['@babel/preset-env'],
         },
       },
       // We are not extracting CSS from the javascript bundles in development because extracting

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -44,6 +44,7 @@ module.exports = merge(commonConfig, {
         loader: 'babel-loader',
         options: {
           compact: true,
+          presets: ['@babel/preset-env'],
         },
       },
       // Webpack, by default, includes all CSS in the javascript bundles. Unfortunately, that means:


### PR DESCRIPTION
it seems that terser may be trying to minify some non-es5 code when `npm run build` is run in GoCD for the past 3 build attempts.

im hoping that adding the @babel/preset-env preset option to our webpack config's babel-loader will ensure babel is correctly using that preset to ensure everything is transpiled :crossed_fingers:
