### PR TITLE
Adding loading to the base Enterprise App

### DIFF
--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -90,6 +90,7 @@ class EnterpriseApp extends React.Component {
       enableAnalyticsScreen,
       enableSamlConfigurationScreen,
       enableLmsConfigurationsScreen,
+      loading,
     } = this.props;
     const { sidebarWidth } = this.state;
     const {
@@ -113,6 +114,9 @@ class EnterpriseApp extends React.Component {
       );
     }
 
+    if (loading) {
+      return <LoadingMessage className="overview" />;
+    }
     return (
       <div className="enterprise-app">
         <MediaQuery minWidth={breakpoints.large.minWidth}>
@@ -261,6 +265,7 @@ EnterpriseApp.defaultProps = {
   enableSamlConfigurationScreen: false,
   enableAnalyticsScreen: false,
   enableLmsConfigurationsScreen: false,
+  loading: true,
 };
 
 EnterpriseApp.propTypes = {
@@ -286,6 +291,7 @@ EnterpriseApp.propTypes = {
   enableAnalyticsScreen: PropTypes.bool,
   enableLmsConfigurationsScreen: PropTypes.bool,
   error: PropTypes.instanceOf(Error),
+  loading: PropTypes.bool,
 };
 
 export default EnterpriseApp;

--- a/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
@@ -26,6 +26,7 @@ getAuthenticatedUser.mockReturnValue({
 });
 
 const mockStore = configureMockStore([thunk]);
+
 const initialState = {
   dashboardAnalytics: {},
   portalConfiguration: {
@@ -33,6 +34,7 @@ const initialState = {
     enableCodeManagementScreen: true,
     enableSubscriptionManagementScreen: true,
     enableAnalyticsScreen: true,
+    loading: false,
   },
   csv: {},
   table: {
@@ -103,6 +105,20 @@ describe('<EnterpriseApp />', () => {
     ));
     expect(wrapper.find(NotFoundPage).length).toEqual(1);
     expect(wrapper.text()).toContain(404);
+  });
+
+  it('renders the load page correctly', () => {
+    const store = mockStore({
+      ...initialState,
+      portalConfiguration: {
+        ...initialState.portalConfiguration, loading: true,
+      },
+    });
+
+    const wrapper = mount((
+      <EnterpriseAppWrapper store={store} />
+    ));
+    expect(wrapper.text()).toContain('Loading');
   });
 
   it('renders error page correctly', () => {

--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -18,6 +18,7 @@ const mapStateToProps = (state) => {
     enableLmsConfigurationsScreen: state.portalConfiguration.enableLmsConfigurationsScreen,
     enterpriseId: state.portalConfiguration.enterpriseId,
     enterpriseName: state.portalConfiguration.enterpriseName,
+    loading: state.portalConfiguration.loading,
   };
 };
 

--- a/src/data/reducers/portalConfiguration.js
+++ b/src/data/reducers/portalConfiguration.js
@@ -6,7 +6,7 @@ import {
 } from '../constants/portalConfiguration';
 
 const initialState = {
-  loading: false,
+  loading: true,
   error: null,
   contactEmail: null,
   enterpriseId: null,

--- a/src/data/reducers/portalConfiguration.test.js
+++ b/src/data/reducers/portalConfiguration.test.js
@@ -6,7 +6,7 @@ import {
 } from '../constants/portalConfiguration';
 
 const initialState = {
-  loading: false,
+  loading: true,
   error: null,
   contactEmail: null,
   enterpriseId: null,
@@ -45,8 +45,11 @@ describe('portalConfiguration reducer', () => {
   });
 
   it('updates fetch portal configuration success state', () => {
+    const succeededState = { ...initialState };
+    succeededState.loading = false;
+
     const expected = {
-      ...initialState,
+      ...succeededState,
       contactEmail: enterpriseData.contact_email,
       enterpriseId: enterpriseData.uuid,
       enterpriseName: enterpriseData.name,
@@ -66,9 +69,11 @@ describe('portalConfiguration reducer', () => {
   });
 
   it('updates fetch portal configuration failure state', () => {
+    const failedState = { ...initialState };
+    failedState.loading = false;
     const error = Error('Network Request');
     const expected = {
-      ...initialState,
+      ...failedState,
       error,
     };
     expect(portalConfiguration(undefined, {


### PR DESCRIPTION
When the admin portal first refreshes/loads, we fetch the configurations for each potential tab the user/enterprise has setup. These configurations are setup so that if none are loaded, we default to the `NotFound` base component, which has created the situation where there is the small amount of time between the initial loading of the page and the fetching of the configurations where nothing is set, so we flash the `Not Found` page. 

The fix here is pretty straight forward- change the default loading state of fetch configurations redux to `true` and render in a loading component to the Enterprise App until that loading prop is `false`. This way we still have a not found page if the user is somewhere weird, but don't flash it to the user if they refresh the page.

**What we don't want:**
![image](https://user-images.githubusercontent.com/67655836/108745460-1b69b500-7509-11eb-96c9-5488b5b66867.png)

**What we want:**
![image](https://user-images.githubusercontent.com/67655836/108745741-77343e00-7509-11eb-9d13-b76da874ee58.png)

Pretty sure there's some straightforward testing to do here, but would love some pointers on where to look
