### PR TITLE
fix: revert to openedx theme in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1295,9 +1295,9 @@
       "integrity": "sha512-XylKOsWRyQm9sNanZnppRORXTLaL34uThyBQpTFwOGAYvNg9PeYsyTTfLA1FTCh02RV+kiwt/O/y14DR/OqpWg=="
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-edx.org@1.4.2",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.4.2.tgz",
-      "integrity": "sha512-BUP7CQ3mookaIpKCntQZWd6uwF1V88sDJn+gSFMG2oVFdIV+OJOEb6VF4sbor7LfARZpomniMjPta0z+ablUmA=="
+      "version": "npm:@edx/brand-openedx@1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
+      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
     },
     "@edx/eslint-config": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@babel/plugin-transform-runtime": "7.12.1",
-    "@edx/brand": "npm:@edx/brand-edx.org@^1.4.2",
+    "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
     "@edx/frontend-enterprise": "^4.6.2",
     "@edx/frontend-platform": "1.8.2",
     "@edx/paragon": "^13.12.0",


### PR DESCRIPTION
Reverts the installation of @edx/brand-edx.org in favor of @edx/brand-openedx. 

@edx/brand-edx.org is installed at build time in GoCD via an npm alias, but is often installed during local development to make sure what we're doing will look good with the new theme. It's too easy to miss reverting the install of @edx/brand-edx.org, though.