### PR TITLE
feat: fix brand style issue by only importing course-search styles

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -5,7 +5,7 @@ $modal-max-width: 650px;
 @import "~@edx/brand/paragon/variables";
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/brand/paragon/overrides";
-@import "~@edx/frontend-enterprise/dist/frontend-enterprise";
+@import "~@edx/frontend-enterprise/src/course-search/styles/index";
 
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";


### PR DESCRIPTION

JIRA: ENT-4205

Tested locally by:

* changing above import
* [1] verified openedx style applies by default (blue buttons, rounded corners etc)
* [2] did a `npm install --save @edx/brand@npm:@edx/brand-edx.org` to get overriden theme and verified new style (black-ish buttons with flat corners) now show
<img width="436" alt="Screen Shot 2021-02-25 at 12 51 43 PM" src="https://user-images.githubusercontent.com/528166/109195230-430a8880-7768-11eb-86d5-acf7f09d1436.png">


will file another ticket for a slightly more future-proof frontend-enterprise change, but this change will suffice to address this issue for now

