### PR TITLE
ENT-4268: Analytics feature enabled

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -12,7 +12,7 @@ const modifiedConfig = {
       FEATURE_FLAGS: {
         CODE_MANAGEMENT: true,
         REPORTING_CONFIGURATIONS: true,
-        ANALYTICS: false,
+        ANALYTICS: true,
         SUPPORT: true,
         SAML_CONFIGURATION: true,
         CODE_VISIBILITY: false,


### PR DESCRIPTION
Description: This PR enables the Analytics feature in production for those enterprises who have this feature enabled in their django admin configurations.

![image](https://user-images.githubusercontent.com/34648393/110775114-5c3f2900-8280-11eb-808c-eb44654f29cb.png)
