### PR TITLE
ENT-4307 : remote extra Router element and replace local history with one from platform

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Router } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 
 import { AuthenticatedPageRoute, PageRoute, AppProvider } from '@edx/frontend-platform/react';
@@ -16,55 +16,52 @@ import SupportPage from '../SupportPage';
 import { ToastsProvider, Toasts } from '../Toasts';
 
 import store from '../../data/store';
-import history from '../../data/history';
 
 const AppWrapper = () => {
   const apiClient = getAuthenticatedHttpClient();
   return (
     <AppProvider store={store}>
-      <Router history={history}>
-        <ToastsProvider>
-          <Helmet
-            titleTemplate="%s - edX Admin Portal"
-            defaultTitle="edX Admin Portal"
+      <ToastsProvider>
+        <Helmet
+          titleTemplate="%s - edX Admin Portal"
+          defaultTitle="edX Admin Portal"
+        />
+        <Toasts />
+        <Header />
+        <Switch>
+          <PageRoute exact path="/public/support" component={SupportPage} />
+          <AuthenticatedPageRoute
+            path="/enterprises"
+            render={(routerProps) => <EnterpriseIndexPage {...routerProps} />}
+            authenticatedAPIClient={apiClient}
+            redirect={`${process.env.BASE_URL}/enterprises`}
           />
-          <Toasts />
-          <Header />
-          <Switch>
-            <PageRoute exact path="/public/support" component={SupportPage} />
-            <AuthenticatedPageRoute
-              path="/enterprises"
-              render={(routerProps) => <EnterpriseIndexPage {...routerProps} />}
-              authenticatedAPIClient={apiClient}
-              redirect={`${process.env.BASE_URL}/enterprises`}
-            />
-            <PageRoute
-              exact
-              path="/:enterpriseSlug/admin/register"
-              component={AdminRegisterPage}
-            />
-            <PageRoute
-              exact
-              path="/:enterpriseSlug/admin/register/activate"
-              component={UserActivationPage}
-            />
-            <AuthenticatedPageRoute
-              path="/:enterpriseSlug"
-              component={EnterpriseApp}
-              authenticatedAPIClient={apiClient}
-              redirect={process.env.BASE_URL}
-            />
-            <AuthenticatedPageRoute
-              path="/"
-              render={(routerProps) => <EnterpriseIndexPage {...routerProps} />}
-              authenticatedAPIClient={apiClient}
-              redirect={process.env.BASE_URL}
-            />
-            <PageRoute component={NotFoundPage} />
-          </Switch>
-          <Footer />
-        </ToastsProvider>
-      </Router>
+          <PageRoute
+            exact
+            path="/:enterpriseSlug/admin/register"
+            component={AdminRegisterPage}
+          />
+          <PageRoute
+            exact
+            path="/:enterpriseSlug/admin/register/activate"
+            component={UserActivationPage}
+          />
+          <AuthenticatedPageRoute
+            path="/:enterpriseSlug"
+            component={EnterpriseApp}
+            authenticatedAPIClient={apiClient}
+            redirect={process.env.BASE_URL}
+          />
+          <AuthenticatedPageRoute
+            path="/"
+            render={(routerProps) => <EnterpriseIndexPage {...routerProps} />}
+            authenticatedAPIClient={apiClient}
+            redirect={process.env.BASE_URL}
+          />
+          <PageRoute component={NotFoundPage} />
+        </Switch>
+        <Footer />
+      </ToastsProvider>
     </AppProvider>
   );
 };

--- a/src/data/history.js
+++ b/src/data/history.js
@@ -1,3 +1,0 @@
-import { createBrowserHistory } from 'history';
-
-export default createBrowserHistory();

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,10 +7,10 @@ import isEmail from 'validator/lib/isEmail';
 import isEmpty from 'validator/lib/isEmpty';
 import isNumeric from 'validator/lib/isNumeric';
 
+import { history } from '@edx/frontend-platform/initialize';
 import { EMAIL_TEMPLATE_FIELD_MAX_LIMIT, OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT } from './data/constants/emailTemplate';
 import { EMAIL_ADDRESS_TEXT_FORM_DATA, EMAIL_ADDRESS_CSV_FORM_DATA } from './data/constants/addUsers';
 import { ENTERPRISE_ADMIN_ROLE_NAME } from './data/constants';
-import history from './data/history';
 
 const formatTimestamp = ({ timestamp, format = 'MMMM D, YYYY' }) => {
   if (timestamp) {


### PR DESCRIPTION
Based on observation and doc at https://github.com/edx/frontend-platform/blob/master/src/initialize.js#L81

there is an extra Router now in the component tree, and also history should be used from frontend-platform to avoid cross-talk

https://github.com/edx/frontend-platform/blob/master/src/initialize.js#L81

Testing:

Locally navigated through app and tested back button etc.

If any more testing needed , can try those.
