### PR TITLE
feat: ENT-4197: improve error messaging formatting, and also report to NewRelic/console on errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@
 node_modules
 npm-debug.log
 coverage
-module.config.js
+module.config.js*
 
 dist/
 .idea
 
 # emacs
 *~
+
+# edx
+.env.private

--- a/src/components/BulkEnrollmentModal/index.jsx
+++ b/src/components/BulkEnrollmentModal/index.jsx
@@ -11,7 +11,6 @@ import {
 
 import TextAreaAutoSize from '../TextAreaAutoSize';
 import CsvUpload from '../CsvUpload';
-import { truncateString } from '../../utils';
 
 class BulkEnrollmentModal extends React.Component {
   constructor(props) {
@@ -77,11 +76,10 @@ class BulkEnrollmentModal extends React.Component {
       .catch((error) => {
         const { customAttributes } = error;
         // fall back to the error.message instead of showing no information but prefer the
-        // cleaner info from customAttributes
-        const customErrMessage = truncateString(
-          customAttributes ? (customAttributes.httpErrorResponseData || error.message) : error.message,
-          240,
-        );
+        // cleaner info from customAttributes (frontend-platform)
+        const customErrMessage = customAttributes ? (customAttributes.httpErrorResponseData || error.message)
+          : error.message;
+
         logError(error, { enterpriseUuid });
         throw new SubmissionError({
           _error: [customErrMessage],

--- a/src/components/BulkEnrollmentModal/index.jsx
+++ b/src/components/BulkEnrollmentModal/index.jsx
@@ -119,9 +119,13 @@ class BulkEnrollmentModal extends React.Component {
             The following emails addresses are not yet associated with a subscription.
             Please take note of the following learners and invite them from the subscription management page.
           </p>
-          {failedLearners.map((failedLearner) => (
-            <p className="mb-1 alert-email" key={`${failedLearner}-email`}>{failedLearner}</p>
-          ))}
+          <ul className="list-group">
+            {failedLearners.map(failedLearner => (
+              <li className="list-group-item mb-1 alert-email" key={`${failedLearner}-email`}>
+                {failedLearner}
+              </li>
+            ))}
+          </ul>
         </Alert>
       </div>
     );

--- a/src/components/BulkEnrollmentModal/index.jsx
+++ b/src/components/BulkEnrollmentModal/index.jsx
@@ -7,7 +7,6 @@ import {
 import { logError } from '@edx/frontend-platform/logging';
 import {
   Alert, Button, Icon, Modal,
-
 } from '@edx/paragon';
 
 import TextAreaAutoSize from '../TextAreaAutoSize';
@@ -92,6 +91,21 @@ class BulkEnrollmentModal extends React.Component {
 
   renderErrorMessage() {
     const { error } = this.props;
+    let errorRendered = error;
+    // handle 'non_field_error' as a special case for better UX, if we can parse it
+    try {
+      const errorAsJson = JSON.parse(error);
+      if (errorAsJson.non_field_errors) {
+        errorRendered = (
+          <>
+            <p>The following errors were encountered:</p>
+            <ul className="list-group">
+              {errorAsJson.non_field_errors.map(err => <li key={err}>{err}</li>)}
+            </ul>
+          </>
+        );
+      }
+    } catch (parseError) { errorRendered = error; }
     return (
       <div
         ref={this.errorMessageRef}
@@ -99,7 +113,7 @@ class BulkEnrollmentModal extends React.Component {
       >
         <Alert variant="danger">
           <Alert.Heading>Unable to enroll learners</Alert.Heading>
-          <p className="alert-body text-break">{error}</p>
+          <p className="alert-body text-break">{errorRendered}</p>
         </Alert>
       </div>
     );

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -270,7 +270,7 @@ class CodeReminderModal extends React.Component {
             >
               <>
                 {mode === 'remind' && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                {'Remind'}
+                Remind
               </>
             </Button>,
             <SaveTemplateButton

--- a/src/utils.js
+++ b/src/utils.js
@@ -306,6 +306,13 @@ const getSubscriptionContactText = (contactEmail) => {
   return `${contactText}.`;
 };
 
+function truncateString(str, maxStrLength = 10) {
+  if (str.length <= maxStrLength) {
+    return str;
+  }
+  return `${str.slice(0, maxStrLength)}...`;
+}
+
 export {
   formatPercentage,
   formatPassedTimestamp,
@@ -331,4 +338,5 @@ export {
   getProxyLoginUrl,
   hasEnterpriseAdminRole,
   getSubscriptionContactText,
+  truncateString,
 };


### PR DESCRIPTION
Changes included to improve error messaging:

- [X] lists multiple validation errors from non_field_errors case instead of printing them raw which looks bad
- [X] Change error alert title from `Unable to assign codes` to `Unable to enroll learners`
- [X] justify text of alert, and make alert text-wrap for better viewing of content
- [X] remove the Cross button from the Alert message ( takes care of ENT-4200 )
- [X] some margin changes in reporting failed learners
- [X] logError to report to console and/or new relic when bulk enrollment fails
- [X] enhance reporting of message by reporting on the customAttributes available from frontend-platform instead of the raw `error.message`, it is a bit cleaner
- [X] some misc cleanup and .gitignore changes

### Work not included:
Another round of improvements will come once the new backend is in place since then we can make more 'intelligent' error messages (there is another ticket to decide error messages)


### Some screenshots after changes

#### removed truncation so ignore that in below screenshots
<img width="618" alt="Screen Shot 2021-03-17 at 10 11 52 AM" src="https://user-images.githubusercontent.com/528166/111481442-59718780-8709-11eb-9920-4e13c907d9e2.png">

### some failure cases 
<img width="542" alt="Screen Shot 2021-03-16 at 5 53 49 PM" src="https://user-images.githubusercontent.com/528166/111385953-e4a73a80-8681-11eb-80b7-8fc293fcf531.png">
<img width="541" alt="Screen Shot 2021-03-16 at 3 32 34 PM" src="https://user-images.githubusercontent.com/528166/111385955-e53fd100-8681-11eb-81af-36ce67f803c3.png">
<img width="540" alt="Screen Shot 2021-03-16 at 3 12 17 PM" src="https://user-images.githubusercontent.com/528166/111385956-e53fd100-8681-11eb-9589-fd11ddddd984.png">
<img width="535" alt="Screen Shot 2021-03-16 at 10 06 45 PM" src="https://user-images.githubusercontent.com/528166/111404012-63ad6a80-86a4-11eb-87bc-d7561b7dc260.png">

#### case of non_field_errors (bad fields, no input provided etc)
<img width="538" alt="Screen Shot 2021-03-16 at 10 33 38 PM" src="https://user-images.githubusercontent.com/528166/111405992-d79d4200-86a7-11eb-9d7d-aa4a2ad3a7fc.png">

