### PR TITLE
ENT-4310: Allow Enterprise Customers to Select Catalogs to receive content metadata reports

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -131,7 +131,7 @@ class ReportingConfigForm extends React.Component {
   }
 
   render() {
-    const { config } = this.props;
+    const { config, availableCatalogs } = this.props;
     const {
       frequency,
       invalidFields,
@@ -139,6 +139,7 @@ class ReportingConfigForm extends React.Component {
       active,
       submitState,
     } = this.state;
+    const selectedCatalogs = (config?.enterpriseCustomerCatalogs || []).map(item => item.uuid);
 
     return (
       <form
@@ -327,10 +328,31 @@ class ReportingConfigForm extends React.Component {
             handleBlur={this.handleBlur}
           />
         )}
+        <div className="col">
+          <ValidationFormGroup
+            for="enterpriseCustomerCatalogs"
+            helpText="The catalogs that should be included in the report. No selection means all catalogs will be included."
+          >
+            <label htmlFor="enterpriseCustomerCatalogs">Enterprise Customer Catalogs</label>
+            <Input
+              type="select"
+              id="enterpriseCustomerCatalogs"
+              name="enterpriseCustomerCatalogUuids"
+              multiple
+              defaultValue={selectedCatalogs}
+              options={
+                availableCatalogs.map(item => ({
+                  value: item.uuid,
+                  label: `Catalog "${item.title}" with UUID "${item.uuid}"`,
+                }))
+              }
+            />
+          </ValidationFormGroup>
+        </div>
         <div className="row justify-content-between align-items-center form-group">
           <ValidationFormGroup
             for="submitButton"
-            invalidMessage="There was an error submiting, please try again."
+            invalidMessage="There was an error submitting, please try again."
             invalid={submitState === SUBMIT_STATES.ERROR}
             className="mb-0"
           >
@@ -391,7 +413,15 @@ ReportingConfigForm.propTypes = {
     sftpUsername: PropTypes.string,
     pgpEncryptionKey: PropTypes.string,
     uuid: PropTypes.string,
+    enterpriseCustomerCatalogs: PropTypes.arrayOf(PropTypes.shape({
+      uuid: PropTypes.string,
+      title: PropTypes.string,
+    })),
   }),
+  availableCatalogs: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string,
+    title: PropTypes.string,
+  })).isRequired,
   createConfig: PropTypes.func.isRequired,
   updateConfig: PropTypes.func,
   deleteConfig: PropTypes.func,

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -19,7 +19,16 @@ const config = {
   reportType: 'csv',
   pgpEncryptionKey: '',
   uuid: 'test-config-uuid',
+  enterpriseCustomerCatalogs: [{
+    uuid: 'test-enterprise-customer-catalog',
+    title: 'All Content',
+  }],
 };
+
+const availableCatalogs = [{
+  uuid: 'test-enterprise-customer-catalog',
+  title: 'All Content',
+}];
 
 const createConfig = () => { };
 const updateConfig = () => { };
@@ -31,6 +40,7 @@ describe('<ReportingConfigForm />', () => {
         config={config}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     expect(wrapper.exists('#email')).toEqual(true);
@@ -48,6 +58,7 @@ describe('<ReportingConfigForm />', () => {
         config={config}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     // test empty email field
@@ -67,6 +78,7 @@ describe('<ReportingConfigForm />', () => {
         config={config}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     wrapper.find('input#hourOfDay').simulate('blur');
@@ -81,6 +93,7 @@ describe('<ReportingConfigForm />', () => {
         config={config}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     wrapper.find('.form-control').forEach(input => input.simulate('blur'));
@@ -101,6 +114,7 @@ describe('<ReportingConfigForm />', () => {
         config={configWithOldDataType}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     expect(wrapper.find('select#dataType').prop('disabled')).toBeTruthy();
@@ -111,6 +125,7 @@ describe('<ReportingConfigForm />', () => {
         config={config}
         createConfig={createConfig}
         updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
       />
     ));
     expect(wrapper.find('select#dataType').prop('disabled')).toBeFalsy();
@@ -121,5 +136,18 @@ describe('<ReportingConfigForm />', () => {
       },
     });
     expect(wrapper.find('select#dataType').prop('disabled')).toBeFalsy();
+  });
+  it('Pre-selects enterprise customer catalogs from the reporting config.', () => {
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={config}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+      />
+    ));
+    expect(
+      wrapper.find('select#enterpriseCustomerCatalogs').instance().value = ['test-enterprise-customer-catalog'],
+    );
   });
 });

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -20,6 +20,8 @@ class LmsApiService {
 
   static createPendingUsersUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/link_pending_enterprise_users`
 
+  static enterpriseCustomerCatalogsUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise_catalogs/`
+
   static fetchCourseOutline(courseId) {
     const options = {
       course_id: courseId,
@@ -196,6 +198,10 @@ class LmsApiService {
 
   static createPendingEnterpriseUsers(formData, uuid) {
     return LmsApiService.apiClient().post(`${LmsApiService.createPendingUsersUrl}/${uuid}`, formData);
+  }
+
+  static fetchEnterpriseCustomerCatalogs(enterpriseId) {
+    return LmsApiService.apiClient().get(`${LmsApiService.enterpriseCustomerCatalogsUrl}?enterprise_customer=${enterpriseId}`);
   }
 }
 


### PR DESCRIPTION
__Description:__
As an enterprise customer, I may receive multiple reports and consume different types of data, including course metadata and course run metadata. 
In the admin dashboard today, it is possible for customers to configure catalog reports to be sent to them. However, they do not have the ability to select specific catalogs they would like to receive. See the pied piper admin dashboard for an example: https://portal.edx.org/pied-piper-non-integrated-test/admin/reporting
It would be helpful if there was a way for customers to select which catalog's metadata they would like to receive when configuring a report.
