### PR TITLE
refactor: remove unused endpoint.

### DIFF
--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -194,11 +194,6 @@ class LmsApiService {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/cornerstone/configuration/${configId}/`, formData);
   }
 
-  static sendBulkEnrollment(enterpriseId, options) {
-    const url = `${LmsApiService.enterpriseCustomerUrl}${enterpriseId}/enterprise_learners/`;
-    return LmsApiService.apiClient().post(url, options);
-  }
-
   static createPendingEnterpriseUsers(formData, uuid) {
     return LmsApiService.apiClient().post(`${LmsApiService.createPendingUsersUrl}/${uuid}`, formData);
   }


### PR DESCRIPTION
I should have removed this when swapping our endpoints to use the bulk enrollment endpoint via License Manager, but I forgot!
(See this pr: https://github.com/edx/frontend-app-admin-portal/pull/510)

PS: If you CTRL+F (or CMD+F) through the codebase you may think we're still using this API call but I assure you we aren't. We just named everything exactly the same! 😑 