### PR TITLE
fix: license reminder email doesn't need subject

### DIFF
--- a/src/components/LicenseRemindModal/index.jsx
+++ b/src/components/LicenseRemindModal/index.jsx
@@ -62,7 +62,7 @@ class LicenseRemindModal extends React.Component {
       sendLicenseReminder,
     } = this.props;
     // Validate form data
-    validateEmailTemplateForm(formData, 'email-template-body');
+    validateEmailTemplateForm(formData, 'email-template-body', false);
     // Configure the options to send to the assignment reminder API endpoint
     const options = {
       greeting: formData['email-template-greeting'],

--- a/src/data/validation/email.js
+++ b/src/data/validation/email.js
@@ -111,10 +111,10 @@ is invalid. Please try again.`;
   return errorsDict;
 };
 
-const validateEmailTemplateForm = (formData, templateKey) => {
+const validateEmailTemplateForm = (formData, templateKey, isSubjectRequired = true) => {
   // Takes redux form data and a string template key
   // Throws an error or otherwise returns nothing.
-  const errorsDict = validateEmailTemplateFields(formData, templateKey);
+  const errorsDict = validateEmailTemplateFields(formData, templateKey, isSubjectRequired);
 
   if (Object.keys(errorsDict) > 1 || errorsDict._error.length > 0) {
     throw new SubmissionError(errorsDict);

--- a/src/data/validation/email.test.js
+++ b/src/data/validation/email.test.js
@@ -160,6 +160,13 @@ describe('email validation', () => {
       formData[EMAIL_TEMPLATE_SUBJECT_KEY] = 'Subject';
       expect(validateEmailTemplateForm(formData, templateKey)).toBeUndefined();
     });
+
+    it('returns nothing on successful validation (and no subject is required)', () => {
+      const formData = new FormData();
+      formData[EMAIL_ADDRESS_CSV_FORM_DATA] = ['bobby1@test.com', 'bobby2@test.com'];
+      formData[templateKey] = 'Template 1';
+      expect(validateEmailTemplateForm(formData, templateKey, false)).toBeUndefined();
+    });
   });
 
   describe('validate email address and template form', () => {


### PR DESCRIPTION
When consolidating validation (done as a side effect of this pr: https://github.com/edx/frontend-app-admin-portal/pull/510) I missed a call site in the LicenseRemindModal that actually passed the `isSubjectRequired=false` flag.

As this validation function is used in 2 other Code related modals that *do* require subject, I just created a passthrough parameter to the field validation function.