### PR TITLE
Adding notify learners checkbox to the bulk enrollment modal

### DIFF
--- a/src/components/BulkEnrollmentModal/index.jsx
+++ b/src/components/BulkEnrollmentModal/index.jsx
@@ -9,11 +9,21 @@ import {
   Alert, Button, Icon, Modal,
 } from '@edx/paragon';
 
+import ReduxFormCheckbox from '../ReduxFormCheckbox';
 import TextAreaAutoSize from '../TextAreaAutoSize';
-import { EMAIL_ADDRESS_TEXT_FORM_DATA, EMAIL_ADDRESS_CSV_FORM_DATA } from '../../data/constants/addUsers';
+import {
+  EMAIL_ADDRESS_TEXT_FORM_DATA,
+  EMAIL_ADDRESS_TEXT_LABEL,
+  EMAIL_ADDRESS_CSV_FORM_DATA,
+  EMAIL_ADDRESS_CSV_LABEL,
+  NOTIFY_LEARNERS_FORM_DATA,
+  NOTIFY_LEARNERS_LABEL,
+} from '../../data/constants/addUsers';
 import { returnValidatedEmails } from '../../data/validation/email';
 import FileInput from '../FileInput';
 import { normalizeFileUpload } from '../../utils';
+
+const NOTIFY_LEARNER_DEFAULT_VALUE = true;
 
 class BulkEnrollmentModal extends React.Component {
   constructor(props) {
@@ -65,7 +75,7 @@ class BulkEnrollmentModal extends React.Component {
 
     const options = {
       course_run_keys: selectedCourseRunKeys,
-      notify: true,
+      notify: formData.notify,
     };
     options.emails = returnValidatedEmails(formData);
 
@@ -164,7 +174,7 @@ class BulkEnrollmentModal extends React.Component {
                 id={EMAIL_ADDRESS_TEXT_FORM_DATA}
                 name={EMAIL_ADDRESS_TEXT_FORM_DATA}
                 component={TextAreaAutoSize}
-                label="Email addresses"
+                label={EMAIL_ADDRESS_TEXT_LABEL}
                 type="text"
               />
               <p>To add more than one user, enter one email address per line.</p>
@@ -175,11 +185,20 @@ class BulkEnrollmentModal extends React.Component {
                 id={EMAIL_ADDRESS_CSV_FORM_DATA}
                 name={EMAIL_ADDRESS_CSV_FORM_DATA}
                 component={FileInput}
-                label="Upload email addresses"
+                label={EMAIL_ADDRESS_CSV_LABEL}
                 accept=".csv"
                 normalize={normalizeFileUpload}
               />
               <p>The file must be a CSV containing a single column of email addresses.</p>
+            </div>
+            <div>
+              <Field
+                id={NOTIFY_LEARNERS_FORM_DATA}
+                name={NOTIFY_LEARNERS_FORM_DATA}
+                component={ReduxFormCheckbox}
+                label={NOTIFY_LEARNERS_LABEL}
+                type="checkbox"
+              />
             </div>
           </div>
         </form>
@@ -251,4 +270,5 @@ BulkEnrollmentModal.propTypes = {
 
 export default reduxForm({
   form: 'bulk-enrollment-modal-form',
+  initialValues: { notify: NOTIFY_LEARNER_DEFAULT_VALUE },
 })(BulkEnrollmentModal);

--- a/src/components/BulkEnrollmentModal/index.test.jsx
+++ b/src/components/BulkEnrollmentModal/index.test.jsx
@@ -36,6 +36,7 @@ describe('<BulkEnrollmentModal />', () => {
     // Verify all expected fields are present.
     screen.getByLabelText('Email addresses');
     screen.getByLabelText('Upload email addresses');
+    screen.getByLabelText('Notify learners');
   });
 
   test('submit displays learner error alert if learners do not have valid subscriptions', () => {

--- a/src/components/ReduxFormCheckbox/ReduxFormCheckbox.test.jsx
+++ b/src/components/ReduxFormCheckbox/ReduxFormCheckbox.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import ReduxFormCheckbox from './index';
+
+describe('<ReduxFormCheckbox />', () => {
+  it('renders checked correctly', () => {
+    const inputProp = { checked: true };
+    const component = renderer
+      .create((
+        <ReduxFormCheckbox input={inputProp} />
+      ))
+      .toJSON();
+    expect(component).toMatchSnapshot();
+  });
+  it('renders unchecked correctly', () => {
+    const inputProp = { checked: false };
+    const component = renderer
+      .create((
+        <ReduxFormCheckbox input={inputProp} />
+      ))
+      .toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/ReduxFormCheckbox/__snapshots__/ReduxFormCheckbox.test.jsx.snap
+++ b/src/components/ReduxFormCheckbox/__snapshots__/ReduxFormCheckbox.test.jsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReduxFormCheckbox /> renders checked correctly 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="form-check"
+  >
+    <input
+      checked={true}
+      className="form-check-input position-static"
+      disabled={false}
+      id="active"
+      name="active"
+      type="checkbox"
+    />
+  </div>
+</div>
+`;
+
+exports[`<ReduxFormCheckbox /> renders unchecked correctly 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="form-check"
+  >
+    <input
+      checked={false}
+      className="form-check-input position-static"
+      disabled={false}
+      id="active"
+      name="active"
+      type="checkbox"
+    />
+  </div>
+</div>
+`;

--- a/src/components/ReduxFormCheckbox/index.jsx
+++ b/src/components/ReduxFormCheckbox/index.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, ValidationFormGroup } from '@edx/paragon';
+
+const ReduxFormCheckbox = ({
+  input,
+  label,
+}) => (
+  <ValidationFormGroup
+    for="active"
+  >
+    <Form.Check
+      {...input}
+      type="checkbox"
+      id="active"
+      name="active"
+      checked={input.checked}
+      label={label}
+    />
+  </ValidationFormGroup>
+);
+
+ReduxFormCheckbox.propTypes = {
+  label: PropTypes.string.isRequired,
+  input: PropTypes.shape({
+    checked: PropTypes.bool,
+  }).isRequired,
+};
+
+export default ReduxFormCheckbox;

--- a/src/data/constants/addUsers.js
+++ b/src/data/constants/addUsers.js
@@ -1,7 +1,15 @@
 const EMAIL_ADDRESS_TEXT_FORM_DATA = 'email-addresses';
 const EMAIL_ADDRESS_CSV_FORM_DATA = 'csv-email-addresses';
+const NOTIFY_LEARNERS_FORM_DATA = 'notify';
+const NOTIFY_LEARNERS_LABEL = 'Notify learners';
+const EMAIL_ADDRESS_CSV_LABEL = 'Upload email addresses';
+const EMAIL_ADDRESS_TEXT_LABEL = 'Email addresses';
 
 export {
   EMAIL_ADDRESS_TEXT_FORM_DATA,
   EMAIL_ADDRESS_CSV_FORM_DATA,
+  NOTIFY_LEARNERS_FORM_DATA,
+  NOTIFY_LEARNERS_LABEL,
+  EMAIL_ADDRESS_CSV_LABEL,
+  EMAIL_ADDRESS_TEXT_LABEL,
 };


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-4340)

Default state of modal upon opening:
![image](https://user-images.githubusercontent.com/67655836/113219837-2aeac500-9250-11eb-9b00-811420d4a4ea.png)

Goals: Add a checkbox to the bulk enrollment modal that allows the user to enable or disable the option to notify the learners who are being enrolled. Functionally, dictate the `notify` parameter sent to the License manager's validation endpoint from the value by the new checkbox.