### PR TITLE
fix: Frontend Build + Linting workarounds

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,8 @@
   "extends": "@edx/eslint-config",
   "parser": "babel-eslint",
   "rules": {
+    //babel-eslint parser is breaking on template literals right now
+    "template-curly-spacing": "off",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -27,7 +29,30 @@
       "assert": "either",
       "depth": 3
     }],
-    "react/state-in-constructor": [0]
+    "react/state-in-constructor": [0],
+    // babel-eslint parser is breaking on template literals right now
+    // This is a copy from airbnb's indent rule with 'TemplateLiteral' added to ignoredNodes.
+    "indent": ["error", 2, {
+      "SwitchCase": 1,
+      "VariableDeclarator": 1,
+      "outerIIFEBody": 1,
+      "FunctionDeclaration": {
+        "parameters": 1,
+        "body": 1
+      },
+      "FunctionExpression": {
+        "parameters": 1,
+        "body": 1
+      },
+      "CallExpression": {
+        "arguments": 1
+      },
+      "ArrayExpression": 1,
+      "ObjectExpression": 1,
+      "ImportDeclaration": 1,
+      "flatTernaryExpressions": false,
+      "ignoredNodes": ["TemplateLiteral", "JSXElement", "JSXElement > *", "JSXAttribute", "JSXIdentifier", "JSXNamespacedName", "JSXMemberExpression", "JSXSpreadAttribute", "JSXExpressionContainer", "JSXOpeningElement", "JSXClosingElement", "JSXFragment", "JSXOpeningFragment", "JSXClosingFragment", "JSXText", "JSXEmptyExpression", "JSXSpreadChild"]
+    }]
   },
   "env": {
     "jest": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,12 +250,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -349,9 +349,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
-      "integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.13.12",
@@ -360,8 +360,21 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.13.14",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+          "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -473,9 +486,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
-      "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -947,9 +960,9 @@
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.10.tgz",
-      "integrity": "sha512-E+aCW9j7mLq01tOuGV08YzLBt+vSyr4bOPT75B6WrAlrUfmOYOZ/yWk847EH0dv0xXiCihWLEmlX//O30YhpIw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.13.tgz",
+      "integrity": "sha512-SNJU53VM/SjQL0bZhyU+f4kJQz7bQQajnrZRSaU21hruG/NWY41AEM9AWXeXX90pYr/C2yAmTgI6yW3LlLrAUQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0"
@@ -1238,22 +1251,32 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.9",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.13.14",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+          "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -1314,9 +1337,9 @@
       "dev": true
     },
     "@edx/frontend-build": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-build/-/frontend-build-5.6.10.tgz",
-      "integrity": "sha512-+9pZWNnYBZoMGlSar5fRszK9T74h7dROP3rz4189W251ogpNzJfKtM8a47iVBnhQdNu6PR499znrGaRPaZUnEA==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-build/-/frontend-build-5.6.11.tgz",
+      "integrity": "sha512-KGQDl0kf4JRwHAhXiMEQMgBjCBN+5MZUWAnxP/F1LSgMSb9gwiRMZ9FpbYDeFeY2sSkmhkx5TIb+gAJFNSd+ow==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.10.5",
@@ -2629,27 +2652,37 @@
       },
       "dependencies": {
         "@babel/core": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-          "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+          "version": "7.13.14",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+          "integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
-            "@babel/helper-compilation-targets": "^7.13.10",
-            "@babel/helper-module-transforms": "^7.13.0",
+            "@babel/helper-compilation-targets": "^7.13.13",
+            "@babel/helper-module-transforms": "^7.13.14",
             "@babel/helpers": "^7.13.10",
-            "@babel/parser": "^7.13.10",
+            "@babel/parser": "^7.13.13",
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
+            "@babel/traverse": "^7.13.13",
+            "@babel/types": "^7.13.14",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
             "semver": "^6.3.0",
             "source-map": "^0.5.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.13.14",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+          "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -4385,12 +4418,12 @@
       },
       "dependencies": {
         "intl-messageformat-parser": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.4.2.tgz",
-          "integrity": "sha512-VHu6UWgWLJykaSeI1M2DpZMVRLuGCOV91i5I81xnJuAI0MKHP7ZJ3my5naOQkzG10ris3hBr+o5RElF1wQ5IXA==",
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.5.1.tgz",
+          "integrity": "sha512-TvB3LqF2VtP6yI6HXlRT5TxX98HKha6hCcrg9dwlPwNaedVNuQA9KgBdtWKgiyakyCTYHQ+KJeFEstNKfZr64w==",
           "dev": true,
           "requires": {
-            "@formatjs/intl-numberformat": "^5.5.0"
+            "@formatjs/intl-numberformat": "^5.5.2"
           }
         }
       }
@@ -6205,9 +6238,9 @@
       "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "core-js-compat": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",
-      "integrity": "sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.0.tgz",
+      "integrity": "sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.3",
@@ -17003,9 +17036,9 @@
           },
           "dependencies": {
             "domelementtype": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-              "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
               "dev": true
             },
             "entities": {
@@ -17517,9 +17550,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -20148,9 +20181,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
-      "integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz",
+      "integrity": "sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "webpack-merge": "5.4.0"
   },
   "devDependencies": {
-    "@edx/frontend-build": "^5.6.10",
+    "@edx/frontend-build": "5.6.11",
     "@intervolga/optimize-cssnano-plugin": "1.0.6",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "10.4.9",

--- a/src/components/BulkEnrollmentModal/index.jsx
+++ b/src/components/BulkEnrollmentModal/index.jsx
@@ -211,7 +211,7 @@ class BulkEnrollmentModal extends React.Component {
           >
             <>
               {submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-              {'Enroll Learners'}
+              Enroll Learners
             </>
           </Button>,
         ]}

--- a/src/components/LicenseRemindModal/index.jsx
+++ b/src/components/LicenseRemindModal/index.jsx
@@ -181,7 +181,7 @@ class LicenseRemindModal extends React.Component {
             >
               <>
                 {submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                {'Send Reminder'}
+                Send Reminder
               </>
             </Button>,
           ]}


### PR DESCRIPTION
Devs locally are getting errors and having MFEs actually just crash due to the webpack hot reload dev server in Frontend-build version 5.6.10. Frontend-build was updated to include a necessary config flag to fix this. This PR just updates to the latest frontend-build (5.6.11) to get that change.

This also has linter workarounds as frontend-build also updates some babel packages which are broken on Template Literals.
If you are here because of this error: `TypeError: Cannot read property 'range' of null` you can see the linter rules updated in eslintrc below to address this issue (hopefully temporarily). I believe a new version of babel/parser needs to come out for this to be fixed. 

There are a lot of old issues that reference this error, so I'm not going to link to any particular one as they all keep getting closed and are on archived repos.
