### PR TITLE
feat: Add subscription selection for bulk enrollment

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -8,6 +8,8 @@ import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import { SearchHeader, SearchData } from '@edx/frontend-enterprise';
 import CourseSearchResults from './CourseSearchResults';
 import { configuration } from '../../config';
+import { useSubscriptionFromParams } from '../subscriptions/data/contextHooks';
+import { NotFound } from '../NotFoundPage';
 
 const searchClient = algoliasearch(
   configuration.ALGOLIA.APP_ID,
@@ -18,7 +20,12 @@ export const NO_DATA_MESSAGE = 'There are no results';
 
 const CourseSearch = ({ enterpriseId, enterpriseSlug, match }) => {
   const PAGE_TITLE = `Search courses - ${enterpriseId}`;
-  const { params: { subscriptionCatalogUuid } } = match;
+  const subscription = useSubscriptionFromParams({ match });
+  if (!subscription) {
+    return (
+      <NotFound />
+    );
+  }
 
   return (
     <SearchData>
@@ -28,7 +35,7 @@ const CourseSearch = ({ enterpriseId, enterpriseSlug, match }) => {
         searchClient={searchClient}
       >
         <Configure
-          filters={`enterprise_catalog_uuids:${subscriptionCatalogUuid}`}
+          filters={`enterprise_catalog_uuids:${subscription.enterpriseCatalogUuid}`}
           hitsPerPage={25}
         />
         <SearchHeader />
@@ -51,11 +58,7 @@ CourseSearch.propTypes = {
   enterpriseId: PropTypes.string,
   enterpriseSlug: PropTypes.string,
   // from react-router
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      subscriptionCatalogUuid: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  match: PropTypes.shape({}).isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -16,8 +16,9 @@ const searchClient = algoliasearch(
 
 export const NO_DATA_MESSAGE = 'There are no results';
 
-const CourseSearch = ({ enterpriseId, enterpriseSlug }) => {
+const CourseSearch = ({ enterpriseId, enterpriseSlug, match }) => {
   const PAGE_TITLE = `Search courses - ${enterpriseId}`;
+  const { params: { subscriptionCatalogUuid } } = match;
 
   return (
     <SearchData>
@@ -27,7 +28,7 @@ const CourseSearch = ({ enterpriseId, enterpriseSlug }) => {
         searchClient={searchClient}
       >
         <Configure
-          filters={`enterprise_customer_uuids:${enterpriseId}`}
+          filters={`enterprise_catalog_uuids:${subscriptionCatalogUuid}`}
           hitsPerPage={25}
         />
         <SearchHeader />
@@ -46,8 +47,15 @@ CourseSearch.defaultProps = {
 };
 
 CourseSearch.propTypes = {
+  // from redux-store
   enterpriseId: PropTypes.string,
   enterpriseSlug: PropTypes.string,
+  // from react-router
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      subscriptionCatalogUuid: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -18,8 +18,10 @@ const searchClient = algoliasearch(
 
 export const NO_DATA_MESSAGE = 'There are no results';
 
-const CourseSearch = ({ enterpriseId, enterpriseSlug, match }) => {
-  const PAGE_TITLE = `Search courses - ${enterpriseId}`;
+const CourseSearch = ({
+  enterpriseId, enterpriseSlug, enterpriseName, match,
+}) => {
+  const PAGE_TITLE = `Search courses - ${enterpriseName}`;
   const subscription = useSubscriptionFromParams({ match });
   if (!subscription) {
     return (
@@ -51,12 +53,14 @@ const CourseSearch = ({ enterpriseId, enterpriseSlug, match }) => {
 CourseSearch.defaultProps = {
   enterpriseId: '',
   enterpriseSlug: '',
+  enterpriseName: '',
 };
 
 CourseSearch.propTypes = {
   // from redux-store
   enterpriseId: PropTypes.string,
   enterpriseSlug: PropTypes.string,
+  enterpriseName: PropTypes.string,
   // from react-router
   match: PropTypes.shape({}).isRequired,
 };
@@ -64,6 +68,7 @@ CourseSearch.propTypes = {
 const mapStateToProps = state => ({
   enterpriseId: state.portalConfiguration.enterpriseId,
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+  enterpriseName: state.portalConfiguration.enterpriseName,
 });
 
 export default connect(mapStateToProps)(CourseSearch);

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -23,7 +23,7 @@ function BulkEnrollmentPage({ enterpriseId }) {
                     {...routeProps}
                     redirectPage="catalog_management"
                     useCatalog
-                    leadText="Enroll your learners in courses"
+                    leadText="Choose a subscription to enroll your learners in courses"
                     buttonText="Enroll learners"
                   />
                 </Container>

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -16,12 +16,12 @@ function BulkEnrollmentPage({ enterpriseId }) {
         <main role="main" className="manage-subscription">
           <Switch>
             <Route
-              path="/:enterpriseSlug/admin/catalog_management"
+              path="/:enterpriseSlug/admin/catalog-management"
               component={routeProps => (
                 <Container className="py-3" fluid>
                   <MultipleSubscriptionsPage
                     {...routeProps}
-                    redirectPage="catalog_management"
+                    redirectPage="catalog-management"
                     useCatalog
                     leadText="Choose a subscription to enroll your learners in courses"
                     buttonText="Enroll learners"
@@ -31,7 +31,7 @@ function BulkEnrollmentPage({ enterpriseId }) {
               exact
             />
             <Route
-              path="/:enterpriseSlug/admin/catalog_management/:subscriptionUUID"
+              path="/:enterpriseSlug/admin/catalog-management/:subscriptionUUID"
               component={CourseSearch}
               exact
             />

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -31,7 +31,7 @@ function BulkEnrollmentPage({ enterpriseId }) {
               exact
             />
             <Route
-              path="/:enterpriseSlug/admin/catalog_management/:subscriptionCatalogUuid"
+              path="/:enterpriseSlug/admin/catalog_management/:subscriptionUUID"
               component={CourseSearch}
               exact
             />

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -18,8 +18,14 @@ function BulkEnrollmentPage({ enterpriseId }) {
             <Route
               path="/:enterpriseSlug/admin/catalog_management"
               component={routeProps => (
-                <Container className="py3" fluid>
-                  <MultipleSubscriptionsPage {...routeProps} redirectPage="catalog_management" useCatalog />
+                <Container className="py-3" fluid>
+                  <MultipleSubscriptionsPage
+                    {...routeProps}
+                    redirectPage="catalog_management"
+                    useCatalog
+                    leadText="Enroll your learners in courses"
+                    buttonText="Enroll learners"
+                  />
                 </Container>
               )}
               exact

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -1,15 +1,37 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Hero from '../Hero';
+import { Container } from '@edx/paragon';
 
+import { Switch, Route } from 'react-router-dom';
+import Hero from '../Hero';
+import { MultipleSubscriptionsPage, SubscriptionData } from '../subscriptions';
 import CourseSearch from './CourseSearch';
 
 function BulkEnrollmentPage({ enterpriseId }) {
   return (
     <div className="container-fluid bulk-enrollment">
       <Hero title="Catalog Management" />
-      <CourseSearch enterpriseId={enterpriseId} />
+      <SubscriptionData enterpriseId={enterpriseId}>
+        <main role="main" className="manage-subscription">
+          <Switch>
+            <Route
+              path="/:enterpriseSlug/admin/catalog_management"
+              component={routeProps => (
+                <Container className="py3" fluid>
+                  <MultipleSubscriptionsPage {...routeProps} redirectPage="catalog_management" useCatalog />
+                </Container>
+              )}
+              exact
+            />
+            <Route
+              path="/:enterpriseSlug/admin/catalog_management/:subscriptionCatalogUuid"
+              component={CourseSearch}
+              exact
+            />
+          </Switch>
+        </main>
+      </SubscriptionData>
     </div>
   );
 }

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -176,8 +176,7 @@ class EnterpriseApp extends React.Component {
                   {(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen)
                     && (
                     <Route
-                      key="bulk-enrollment"
-                      exact
+                      key="catalog_management"
                       path={`${baseUrl}/admin/catalog_management`}
                       render={routeProps => <BulkEnrollmentPage {...routeProps} />}
                     />

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -176,8 +176,8 @@ class EnterpriseApp extends React.Component {
                   {(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen)
                     && (
                     <Route
-                      key="catalog_management"
-                      path={`${baseUrl}/admin/catalog_management`}
+                      key="catalog-management"
+                      path={`${baseUrl}/admin/catalog-management`}
                       render={routeProps => <BulkEnrollmentPage {...routeProps} />}
                     />
                     )}

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -91,7 +91,7 @@ class Sidebar extends React.Component {
       },
       {
         title: 'Catalog Management',
-        to: `${baseUrl}/admin/catalog_management`,
+        to: `${baseUrl}/admin/catalog-management`,
         icon: faBookOpen,
         hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),
       },

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -10,7 +10,7 @@ import SubscriptionCard from './SubscriptionCard';
 import { DEFAULT_LEAD_TEXT } from './data/constants';
 
 const MultipleSubscriptionsPicker = ({
-  enterpriseSlug, useCatalog, leadText, buttonText, redirectPage, subscriptions,
+  enterpriseSlug, leadText, buttonText, redirectPage, subscriptions,
 }) => (
   <>
     <Row>
@@ -25,7 +25,7 @@ const MultipleSubscriptionsPicker = ({
       {subscriptions.map(subscription => (
         <SubscriptionCard
           key={subscription?.uuid}
-          uuid={useCatalog ? subscription?.enterpriseCatalogUuid : subscription?.uuid}
+          uuid={subscription?.uuid}
           title={subscription?.title}
           enterpriseSlug={enterpriseSlug}
           startDate={subscription?.startDate}
@@ -41,7 +41,6 @@ const MultipleSubscriptionsPicker = ({
 
 MultipleSubscriptionsPicker.defaultProps = {
   redirectPage: 'subscriptions',
-  useCatalog: false,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,
 };
@@ -51,7 +50,6 @@ MultipleSubscriptionsPicker.propTypes = {
   enterpriseSlug: PropTypes.string.isRequired,
   leadText: PropTypes.string,
   redirectPage: PropTypes.string,
-  useCatalog: PropTypes.bool,
   subscriptions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
 };
 

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  CardGrid,
+  Row,
+  Col,
+} from '@edx/paragon';
+
+import SubscriptionCard from './SubscriptionCard';
+
+export const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
+
+const MultipleSubscriptionsPicker = ({
+  enterpriseSlug, useCatalog, leadText, buttonText, redirectPage, subscriptions,
+}) => (
+  <>
+    <Row>
+      <Col>
+        <h2>Cohorts</h2>
+        <p className="lead">
+          {leadText}
+        </p>
+      </Col>
+    </Row>
+    <CardGrid>
+      {subscriptions.map(subscription => (
+        <SubscriptionCard
+          key={subscription?.uuid}
+          uuid={useCatalog ? subscription?.enterpriseCatalogUuid : subscription?.uuid}
+          title={subscription?.title}
+          enterpriseSlug={enterpriseSlug}
+          startDate={subscription?.startDate}
+          expirationDate={subscription?.expirationDate}
+          licenses={subscription?.licenses || {}}
+          redirectPage={redirectPage}
+          buttonText={buttonText}
+        />
+      ))}
+    </CardGrid>
+  </>
+);
+
+MultipleSubscriptionsPicker.defaultProps = {
+  redirectPage: 'subscriptions',
+  useCatalog: false,
+  leadText: DEFAULT_LEAD_TEXT,
+  buttonText: null,
+};
+
+MultipleSubscriptionsPicker.propTypes = {
+  buttonText: PropTypes.string,
+  enterpriseSlug: PropTypes.string.isRequired,
+  leadText: PropTypes.string,
+  redirectPage: PropTypes.string,
+  useCatalog: PropTypes.bool,
+  subscriptions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+};
+
+export default MultipleSubscriptionsPicker;

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -7,8 +7,7 @@ import {
 } from '@edx/paragon';
 
 import SubscriptionCard from './SubscriptionCard';
-
-export const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
+import { DEFAULT_LEAD_TEXT } from './data/constants';
 
 const MultipleSubscriptionsPicker = ({
   enterpriseSlug, useCatalog, leadText, buttonText, redirectPage, subscriptions,

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -7,7 +7,7 @@ import {
 } from '@edx/paragon';
 
 import SubscriptionCard from './SubscriptionCard';
-import { DEFAULT_LEAD_TEXT } from './data/constants';
+import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from './data/constants';
 
 const MultipleSubscriptionsPicker = ({
   enterpriseSlug, leadText, buttonText, redirectPage, subscriptions,
@@ -40,7 +40,7 @@ const MultipleSubscriptionsPicker = ({
 );
 
 MultipleSubscriptionsPicker.defaultProps = {
-  redirectPage: 'subscriptions',
+  redirectPage: DEFAULT_REDIRECT_PAGE,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,
 };

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -6,8 +6,7 @@ import { SubscriptionContext } from './SubscriptionData';
 
 import SubscriptionExpiration from './expiration/SubscriptionExpiration';
 import MultipleSubscriptionsPicker from './MultipleSubscriptionPicker';
-
-const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
+import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from './data/constants';
 
 const MultipleSubscriptionsPage = ({
   match, redirectPage, useCatalog, leadText, buttonText,
@@ -35,13 +34,14 @@ const MultipleSubscriptionsPage = ({
         leadText={leadText}
         buttonText={buttonText}
         subscriptions={subscriptions}
+        redirectPage={redirectPage}
       />
     </>
   );
 };
 
 MultipleSubscriptionsPage.defaultProps = {
-  redirectPage: 'subscriptions',
+  redirectPage: DEFAULT_REDIRECT_PAGE,
   useCatalog: false,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -1,17 +1,11 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
-import {
-  CardGrid,
-  Row,
-  Col,
-} from '@edx/paragon';
 
 import { SubscriptionContext } from './SubscriptionData';
-import SubscriptionDetailContextProvider from './SubscriptionDetailContextProvider';
-import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBanner';
-import SubscriptionExpirationModal from './expiration/SubscriptionExpirationModal';
-import SubscriptionCard from './SubscriptionCard';
+
+import SubscriptionExpiration from './expiration/SubscriptionExpiration';
+import MultipleSubscriptionsPicker from './MultipleSubscriptionPicker';
 
 const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
 
@@ -32,40 +26,16 @@ const MultipleSubscriptionsPage = ({
     );
   }
 
-  const subscriptionFurthestFromExpiration = subscriptions.reduce((sub1, sub2) => (
-    new Date(sub1.expirationDate) > new Date(sub2.expirationDate) ? sub1 : sub2));
-
   return (
     <>
-      <SubscriptionDetailContextProvider subscription={subscriptionFurthestFromExpiration}>
-        {subscriptionFurthestFromExpiration.daysUntilExpiration > 0 && (
-          <SubscriptionExpirationBanner />
-        )}
-        <SubscriptionExpirationModal />
-      </SubscriptionDetailContextProvider>
-      <Row>
-        <Col>
-          <h2>Cohorts</h2>
-          <p className="lead">
-            {leadText}
-          </p>
-        </Col>
-      </Row>
-      <CardGrid>
-        {subscriptions.map(subscription => (
-          <SubscriptionCard
-            key={subscription?.uuid}
-            uuid={useCatalog ? subscription?.enterpriseCatalogUuid : subscription?.uuid}
-            title={subscription?.title}
-            enterpriseSlug={enterpriseSlug}
-            startDate={subscription?.startDate}
-            expirationDate={subscription?.expirationDate}
-            licenses={subscription?.licenses || {}}
-            redirectPage={redirectPage}
-            buttonText={buttonText}
-          />
-        ))}
-      </CardGrid>
+      <SubscriptionExpiration />
+      <MultipleSubscriptionsPicker
+        enterpriseSlug={enterpriseSlug}
+        useCatalog={useCatalog}
+        leadText={leadText}
+        buttonText={buttonText}
+        subscriptions={subscriptions}
+      />
     </>
   );
 };

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -13,7 +13,7 @@ import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBan
 import SubscriptionExpirationModal from './expiration/SubscriptionExpirationModal';
 import SubscriptionCard from './SubscriptionCard';
 
-const MultipleSubscriptionsPage = ({ match }) => {
+const MultipleSubscriptionsPage = ({ match, redirectPage, useCatalog }) => {
   const { params: { enterpriseSlug } } = match;
   const { data } = useContext(SubscriptionContext);
   const subscriptions = data.results;
@@ -24,7 +24,7 @@ const MultipleSubscriptionsPage = ({ match }) => {
 
   if (subscriptions.length === 1) {
     return (
-      <Redirect to={`/${enterpriseSlug}/admin/subscriptions/${subscriptions[0].uuid}`} />
+      <Redirect to={`/${enterpriseSlug}/admin/${redirectPage}/${subscriptions[0].uuid}`} />
     );
   }
 
@@ -51,12 +51,13 @@ const MultipleSubscriptionsPage = ({ match }) => {
         {subscriptions.map(subscription => (
           <SubscriptionCard
             key={subscription?.uuid}
-            uuid={subscription?.uuid}
+            uuid={useCatalog ? subscription?.enterpriseCatalogUuid : subscription?.uuid}
             title={subscription?.title}
             enterpriseSlug={enterpriseSlug}
             startDate={subscription?.startDate}
             expirationDate={subscription?.expirationDate}
             licenses={subscription?.licenses || {}}
+            redirectPage={redirectPage}
           />
         ))}
       </CardGrid>
@@ -64,12 +65,19 @@ const MultipleSubscriptionsPage = ({ match }) => {
   );
 };
 
+MultipleSubscriptionsPage.defaultProps = {
+  redirectPage: 'subscriptions',
+  useCatalog: false,
+};
+
 MultipleSubscriptionsPage.propTypes = {
+  redirectPage: PropTypes.string,
   match: PropTypes.shape({
     params: PropTypes.shape({
       enterpriseSlug: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  useCatalog: PropTypes.bool,
 };
 
 export default MultipleSubscriptionsPage;

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -9,7 +9,7 @@ import MultipleSubscriptionsPicker from './MultipleSubscriptionPicker';
 import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from './data/constants';
 
 const MultipleSubscriptionsPage = ({
-  match, redirectPage, useCatalog, leadText, buttonText,
+  match, redirectPage, leadText, buttonText,
 }) => {
   const { params: { enterpriseSlug } } = match;
   const { data } = useContext(SubscriptionContext);
@@ -30,7 +30,6 @@ const MultipleSubscriptionsPage = ({
       <SubscriptionExpiration />
       <MultipleSubscriptionsPicker
         enterpriseSlug={enterpriseSlug}
-        useCatalog={useCatalog}
         leadText={leadText}
         buttonText={buttonText}
         subscriptions={subscriptions}
@@ -42,7 +41,6 @@ const MultipleSubscriptionsPage = ({
 
 MultipleSubscriptionsPage.defaultProps = {
   redirectPage: DEFAULT_REDIRECT_PAGE,
-  useCatalog: false,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,
 };
@@ -54,7 +52,6 @@ MultipleSubscriptionsPage.propTypes = {
       enterpriseSlug: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
-  useCatalog: PropTypes.bool,
   leadText: PropTypes.string,
   buttonText: PropTypes.string,
 };

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -13,7 +13,11 @@ import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBan
 import SubscriptionExpirationModal from './expiration/SubscriptionExpirationModal';
 import SubscriptionCard from './SubscriptionCard';
 
-const MultipleSubscriptionsPage = ({ match, redirectPage, useCatalog }) => {
+const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
+
+const MultipleSubscriptionsPage = ({
+  match, redirectPage, useCatalog, leadText, buttonText,
+}) => {
   const { params: { enterpriseSlug } } = match;
   const { data } = useContext(SubscriptionContext);
   const subscriptions = data.results;
@@ -43,7 +47,7 @@ const MultipleSubscriptionsPage = ({ match, redirectPage, useCatalog }) => {
         <Col>
           <h2>Cohorts</h2>
           <p className="lead">
-            Invite your learners to access your course catalog and manage your subscription cohorts
+            {leadText}
           </p>
         </Col>
       </Row>
@@ -58,6 +62,7 @@ const MultipleSubscriptionsPage = ({ match, redirectPage, useCatalog }) => {
             expirationDate={subscription?.expirationDate}
             licenses={subscription?.licenses || {}}
             redirectPage={redirectPage}
+            buttonText={buttonText}
           />
         ))}
       </CardGrid>
@@ -68,6 +73,8 @@ const MultipleSubscriptionsPage = ({ match, redirectPage, useCatalog }) => {
 MultipleSubscriptionsPage.defaultProps = {
   redirectPage: 'subscriptions',
   useCatalog: false,
+  leadText: DEFAULT_LEAD_TEXT,
+  buttonText: null,
 };
 
 MultipleSubscriptionsPage.propTypes = {
@@ -78,6 +85,8 @@ MultipleSubscriptionsPage.propTypes = {
     }).isRequired,
   }).isRequired,
   useCatalog: PropTypes.bool,
+  leadText: PropTypes.string,
+  buttonText: PropTypes.string,
 };
 
 export default MultipleSubscriptionsPage;

--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -11,6 +11,7 @@ const SubscriptionCard = ({
   startDate,
   expirationDate,
   redirectPage,
+  buttonText,
   licenses: {
     allocated,
     total,
@@ -19,6 +20,7 @@ const SubscriptionCard = ({
   const formattedStartDate = moment(startDate).format('MMMM D, YYYY');
   const formattedExpirationDate = moment(expirationDate).format('MMMM D, YYYY');
   const isExpired = moment().isAfter(expirationDate);
+  const buttonDisplayText = buttonText || `${isExpired ? 'View' : 'Manage'} learners`;
 
   return (
     <Card className="subscription-card w-100">
@@ -45,7 +47,7 @@ const SubscriptionCard = ({
         <div className="d-flex">
           <div className="ml-auto">
             <Button as={Link} to={`/${enterpriseSlug}/admin/${redirectPage}/${uuid}`} variant="outline-primary">
-              {isExpired ? 'View' : 'Manage'} learners
+              {buttonDisplayText}
             </Button>
           </div>
         </div>
@@ -56,6 +58,7 @@ const SubscriptionCard = ({
 
 SubscriptionCard.defaultProps = {
   redirectPage: 'subscriptions',
+  buttonText: null,
 };
 
 SubscriptionCard.propTypes = {
@@ -69,6 +72,7 @@ SubscriptionCard.propTypes = {
     total: PropTypes.number.isRequired,
   }).isRequired,
   redirectPage: PropTypes.string,
+  buttonText: PropTypes.string,
 };
 
 export default SubscriptionCard;

--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { Card, Badge, Button } from '@edx/paragon';
+import { DEFAULT_REDIRECT_PAGE } from './data/constants';
 
 const SubscriptionCard = ({
   uuid,
@@ -57,7 +58,7 @@ const SubscriptionCard = ({
 };
 
 SubscriptionCard.defaultProps = {
-  redirectPage: 'subscriptions',
+  redirectPage: DEFAULT_REDIRECT_PAGE,
   buttonText: null,
 };
 

--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -10,6 +10,7 @@ const SubscriptionCard = ({
   enterpriseSlug,
   startDate,
   expirationDate,
+  redirectPage,
   licenses: {
     allocated,
     total,
@@ -43,7 +44,7 @@ const SubscriptionCard = ({
         </p>
         <div className="d-flex">
           <div className="ml-auto">
-            <Button as={Link} to={`/${enterpriseSlug}/admin/subscriptions/${uuid}`} variant="outline-primary">
+            <Button as={Link} to={`/${enterpriseSlug}/admin/${redirectPage}/${uuid}`} variant="outline-primary">
               {isExpired ? 'View' : 'Manage'} learners
             </Button>
           </div>
@@ -51,6 +52,10 @@ const SubscriptionCard = ({
       </Card.Body>
     </Card>
   );
+};
+
+SubscriptionCard.defaultProps = {
+  redirectPage: 'subscriptions',
 };
 
 SubscriptionCard.propTypes = {
@@ -63,6 +68,7 @@ SubscriptionCard.propTypes = {
     allocated: PropTypes.number.isRequired,
     total: PropTypes.number.isRequired,
   }).isRequired,
+  redirectPage: PropTypes.string,
 };
 
 export default SubscriptionCard;

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -1,8 +1,8 @@
 import React, { createContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { useSubscriptionData } from './data/hooks';
 
 import StatusAlert from '../StatusAlert';
-import { useSubscriptionData } from './data/hooks';
 
 export const SubscriptionContext = createContext({});
 

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -1,7 +1,7 @@
 import React, { createContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useSubscriptionData } from './data/hooks';
 
+import { useSubscriptionData } from './data/hooks';
 import StatusAlert from '../StatusAlert';
 
 export const SubscriptionContext = createContext({});

--- a/src/components/subscriptions/SubscriptionDetailPage.jsx
+++ b/src/components/subscriptions/SubscriptionDetailPage.jsx
@@ -1,19 +1,17 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBanner';
 import SubscriptionExpirationModal from './expiration/SubscriptionExpirationModal';
 import SubscriptionDetails from './SubscriptionDetails';
 import LicenseAllocationDetails from './licenses/LicenseAllocationDetails';
 import SubscriptionDetailContextProvider from './SubscriptionDetailContextProvider';
-import { SubscriptionContext } from './SubscriptionData';
+import { useSubscriptionFromParams } from './data/contextHooks';
+
 import { NotFound } from '../NotFoundPage';
 
 const SubscriptionDetailPage = ({ match }) => {
-  // Use UUID to find matching subscription plan in SubscriptionContext, return 404 if not found
-  const { params: { subscriptionUUID } } = match;
-  const { data: subscriptions } = useContext(SubscriptionContext);
-  const subscription = Object.values(subscriptions.results).filter(sub => sub.uuid === subscriptionUUID)[0];
-  if (!subscriptions?.count || !subscription) {
+  const subscription = useSubscriptionFromParams({ match });
+  if (!subscription) {
     return (
       <NotFound />
     );

--- a/src/components/subscriptions/data/constants.js
+++ b/src/components/subscriptions/data/constants.js
@@ -35,3 +35,7 @@ export const SUBSCRIPTION_DAYS_REMAINING_SEVERE = 60;
 export const SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL = 30;
 // Prefix for cookies that determine if the user has seen the modal for that range of expiration
 export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';
+
+// Multiple subscription picker
+export const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
+export const DEFAULT_REDIRECT_PAGE = 'subscriptions';

--- a/src/components/subscriptions/data/contextHooks.jsx
+++ b/src/components/subscriptions/data/contextHooks.jsx
@@ -1,0 +1,19 @@
+/* eslint-disable import/prefer-default-export */
+// This file exists to avoid a dependency cycle that would be present if this function were in the hooks folder.
+import { useContext } from 'react';
+import { SubscriptionContext } from '../SubscriptionData';
+
+/*
+  This hook provides subscription data for an individual enterprise subscription UUID recieved
+  from the subscriptionUUID param in the route.
+*/
+export const useSubscriptionFromParams = ({ match }) => {
+  // Use UUID to find matching subscription plan in SubscriptionContext, return 404 if not found
+  const { params: { subscriptionUUID } } = match;
+  const { data: subscriptions } = useContext(SubscriptionContext);
+  const enterpriseSubscriptions = Object.values(subscriptions.results).filter(sub => sub.uuid === subscriptionUUID);
+  if (!subscriptions.count || enterpriseSubscriptions.length < 1) {
+    return null;
+  }
+  return enterpriseSubscriptions[0];
+};

--- a/src/components/subscriptions/expiration/SubscriptionExpiration.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiration.jsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+
+import { SubscriptionContext } from '../SubscriptionData';
+import SubscriptionDetailContextProvider from '../SubscriptionDetailContextProvider';
+import SubscriptionExpirationBanner from './SubscriptionExpirationBanner';
+import SubscriptionExpirationModal from './SubscriptionExpirationModal';
+
+const SubscriptionExpiration = () => {
+  const { data } = useContext(SubscriptionContext);
+  const subscriptions = data.results;
+
+  const subscriptionFurthestFromExpiration = subscriptions.reduce((sub1, sub2) => (
+    new Date(sub1.expirationDate) > new Date(sub2.expirationDate) ? sub1 : sub2));
+
+  return (
+    <SubscriptionDetailContextProvider subscription={subscriptionFurthestFromExpiration}>
+      {subscriptionFurthestFromExpiration.daysUntilExpiration > 0 && (
+        <SubscriptionExpirationBanner />
+      )}
+      <SubscriptionExpirationModal />
+    </SubscriptionDetailContextProvider>
+  );
+};
+
+export default SubscriptionExpiration;

--- a/src/components/subscriptions/index.js
+++ b/src/components/subscriptions/index.js
@@ -1,2 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as SubscriptionManagementPage } from './SubscriptionManagementPage';
+export { default as MultipleSubscriptionsPage } from './MultipleSubscriptionsPage';
+export { default as SubscriptionData } from './SubscriptionData';

--- a/src/components/subscriptions/licenses/LicenseAllocationDetails.jsx
+++ b/src/components/subscriptions/licenses/LicenseAllocationDetails.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LicenseAllocationNavigation from './LicenseAllocationNavigation';
-import TabContentTable from './TabContentTable';
+import LicenseManagementTabContentTable from './LicenseManagementTabContentTable';
 import LicenseAllocationHeader from './LicenseAllocationHeader';
 
 const LicenseAllocationDetails = () => (
@@ -15,7 +15,7 @@ const LicenseAllocationDetails = () => (
             <LicenseAllocationNavigation />
           </div>
           <div className="col-12 col-lg-9">
-            <TabContentTable />
+            <LicenseManagementTabContentTable />
           </div>
         </div>
       </div>

--- a/src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx
@@ -36,7 +36,7 @@ const columns = [
   },
 ];
 
-const TabContentTable = ({ enterpriseSlug }) => {
+const LicenseManagementTabContentTable = ({ enterpriseSlug }) => {
   const { errors, forceRefresh, setErrors } = useContext(SubscriptionContext);
   const {
     activeTab,
@@ -193,7 +193,7 @@ const TabContentTable = ({ enterpriseSlug }) => {
   );
 };
 
-TabContentTable.propTypes = {
+LicenseManagementTabContentTable.propTypes = {
   enterpriseSlug: PropTypes.string.isRequired,
 };
 
@@ -201,4 +201,4 @@ const mapStateToProps = state => ({
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
 });
 
-export default connect(mapStateToProps)(TabContentTable);
+export default connect(mapStateToProps)(LicenseManagementTabContentTable);

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
@@ -3,24 +3,26 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import userEvent from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import React from 'react';
 import { renderWithRouter } from '../../test/testUtils';
 import { SubscriptionContext } from '../SubscriptionData';
+import { DEFAULT_REDIRECT_PAGE } from '../data/constants';
 
 import MultipleSubscriptionsPage from '../MultipleSubscriptionsPage';
 
+const fakeSlug = 'snail';
 const defaultProps = {
   match: {
     params: {
-      enterpriseSlug: 'sluggy',
+      enterpriseSlug: fakeSlug,
     },
   },
 };
 
+// required for the expiration components
 const fakeStore = {
   portalConfiguration: {
     enterpriseSlug: 'sluggo',
@@ -52,9 +54,9 @@ const defaultSubscriptions = {
         },
       },
     ],
-    setErrors: () => {},
-    errors: null,
   },
+  setErrors: () => {},
+  errors: null,
 };
 
 const mockStore = configureMockStore([thunk]);
@@ -69,11 +71,70 @@ const MultipleSubscriptionsPageWrapper = ({ subscriptions = defaultSubscriptions
 );
 
 describe('MultipleSubscriptionsPage', () => {
-  it('displays a title', () => {
+  it('displays a the MultipleSubscriptionPicker when there are multiple subscriptions', () => {
     renderWithRouter(<MultipleSubscriptionsPageWrapper {...defaultProps} />, {
-      route: '/subscriptions/ABC123',
-      path: '/subscriptions/:enterpriseSlug',
+      route: `/${fakeSlug}/admin/subscriptions/`,
+      path: '/:enterpriseSlug/admin/subscriptions/',
     });
     expect(screen.getByText('Cohorts')).toBeInTheDocument();
+  });
+  it('returns null if there are no subscriptions', () => {
+    const subscriptions = { data: { results: [] } };
+    renderWithRouter(<MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} />, {
+      route: `/${fakeSlug}/admin/subscriptions/`,
+      path: '/:enterpriseSlug/admin/subscriptions/',
+    });
+    expect(screen.queryByText('Cohorts')).not.toBeInTheDocument();
+  });
+  it('redirects if there is only one subscription, default redirectPage', () => {
+    const subsUuid = 'bestuuid';
+    const subscriptions = {
+      data: {
+        results: [{
+          uuid: subsUuid,
+          title: 'Enterprise A',
+          startDate: '2021-04-13',
+          expirationDate: '2024-04-13',
+          licenses: {
+            allocated: 10,
+            total: 20,
+          },
+        }],
+      },
+    };
+    const { history } = renderWithRouter(
+      <MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} />,
+      {
+        route: `/${fakeSlug}/admin/subscriptions/`,
+        path: '/:enterpriseSlug/admin/subscriptions/',
+      },
+    );
+    expect(history.location.pathname).toEqual(`/${fakeSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${subsUuid}`);
+  });
+  it('redirects if there is only one subscription, custom redirect page', () => {
+    const redirectPage = 'bulkenrollment';
+    const subsUuid = 'bestuuid';
+    const subscriptions = {
+      data: {
+        results: [{
+          uuid: subsUuid,
+          title: 'Enterprise A',
+          startDate: '2021-04-13',
+          expirationDate: '2024-04-13',
+          licenses: {
+            allocated: 10,
+            total: 20,
+          },
+        }],
+      },
+    };
+    const { history } = renderWithRouter(
+      <MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} redirectPage={redirectPage} />,
+      {
+        route: `/${fakeSlug}/admin/subscriptions/`,
+        path: '/:enterpriseSlug/admin/subscriptions/',
+      },
+    );
+    expect(history.location.pathname).toEqual(`/${fakeSlug}/admin/${redirectPage}/${subsUuid}`);
   });
 });

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
@@ -1,0 +1,79 @@
+import {
+  screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Provider } from 'react-redux';
+import userEvent from '@testing-library/user-event';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import React from 'react';
+import { renderWithRouter } from '../../test/testUtils';
+import { SubscriptionContext } from '../SubscriptionData';
+
+import MultipleSubscriptionsPage from '../MultipleSubscriptionsPage';
+
+const defaultProps = {
+  match: {
+    params: {
+      enterpriseSlug: 'sluggy',
+    },
+  },
+};
+
+const fakeStore = {
+  portalConfiguration: {
+    enterpriseSlug: 'sluggo',
+    enableCodeManagementScreen: false,
+  },
+};
+
+const defaultSubscriptions = {
+  data: {
+    results: [
+      {
+        uuid: 'ided',
+        title: 'Enterprise A',
+        startDate: '2021-04-13',
+        expirationDate: '2024-04-13',
+        licenses: {
+          allocated: 10,
+          total: 20,
+        },
+      },
+      {
+        uuid: 'anotherid',
+        title: 'Enterprise B',
+        startDate: '2021-03-13',
+        expirationDate: '2024-10-13',
+        licenses: {
+          allocated: 11,
+          total: 30,
+        },
+      },
+    ],
+    setErrors: () => {},
+    errors: null,
+  },
+};
+
+const mockStore = configureMockStore([thunk]);
+
+// eslint-disable-next-line react/prop-types
+const MultipleSubscriptionsPageWrapper = ({ subscriptions = defaultSubscriptions, ...props }) => (
+  <Provider store={mockStore(fakeStore)}>
+    <SubscriptionContext.Provider value={subscriptions}>
+      <MultipleSubscriptionsPage {...props} />
+    </SubscriptionContext.Provider>
+  </Provider>
+);
+
+describe('MultipleSubscriptionsPage', () => {
+  it('displays a title', () => {
+    renderWithRouter(<MultipleSubscriptionsPageWrapper {...defaultProps} />, {
+      route: '/subscriptions/ABC123',
+      path: '/subscriptions/:enterpriseSlug',
+    });
+    expect(screen.getByText('Cohorts')).toBeInTheDocument();
+  });
+});

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
@@ -1,0 +1,56 @@
+import {
+  screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { renderWithRouter } from '../../test/testUtils';
+
+import MultipleSubscriptionsPicker, { DEFAULT_LEAD_TEXT } from '../MultipleSubscriptionPicker';
+
+const defaultProps = {
+  enterpriseSlug: 'sluggy',
+  subscriptions: [
+    {
+      uuid: 'ided',
+      title: 'Enterprise A',
+      startDate: '2021-04-13',
+      expirationDate: '2024-04-13',
+      licenses: {
+        allocated: 10,
+        total: 20,
+      },
+    },
+    {
+      uuid: 'anotherid',
+      title: 'Enterprise B',
+      startDate: '2021-03-13',
+      expirationDate: '2024-10-13',
+      licenses: {
+        allocated: 11,
+        total: 30,
+      },
+    },
+  ],
+};
+
+describe('MultipleSubscriptionsPicker', () => {
+  it('displays a title', () => {
+    renderWithRouter(<MultipleSubscriptionsPicker {...defaultProps} />);
+    expect(screen.getByText('Cohorts')).toBeInTheDocument();
+  });
+  it('displays default lead text by default', () => {
+    renderWithRouter(<MultipleSubscriptionsPicker {...defaultProps} />);
+    expect(screen.getByText(DEFAULT_LEAD_TEXT)).toBeInTheDocument();
+  });
+  it('displays an alternate lead text', () => {
+    const leadText = 'Lead me in';
+    renderWithRouter(<MultipleSubscriptionsPicker {...defaultProps} leadText={leadText} />);
+    expect(screen.getByText(leadText)).toBeInTheDocument();
+  });
+  it('displays a subscription card for each subscription', () => {
+    renderWithRouter(<MultipleSubscriptionsPicker {...defaultProps} />);
+    defaultProps.subscriptions.forEach((subscription) => {
+      expect(screen.getByText(subscription.title)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
@@ -4,8 +4,9 @@ import {
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
 import { renderWithRouter } from '../../test/testUtils';
+import { DEFAULT_LEAD_TEXT } from '../data/constants';
 
-import MultipleSubscriptionsPicker, { DEFAULT_LEAD_TEXT } from '../MultipleSubscriptionPicker';
+import MultipleSubscriptionsPicker from '../MultipleSubscriptionPicker';
 
 const defaultProps = {
   enterpriseSlug: 'sluggy',

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
@@ -1,21 +1,23 @@
-import {
-  screen,
-} from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../test/testUtils';
-import { DEFAULT_LEAD_TEXT } from '../data/constants';
+import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from '../data/constants';
 
 import MultipleSubscriptionsPicker from '../MultipleSubscriptionPicker';
 
+const firstCatalogUuid = 'catalogID1';
+const firstEnterpriseUuid = 'ided';
 const defaultProps = {
   enterpriseSlug: 'sluggy',
   subscriptions: [
     {
-      uuid: 'ided',
+      uuid: firstEnterpriseUuid,
       title: 'Enterprise A',
       startDate: '2021-04-13',
       expirationDate: '2024-04-13',
+      enterpriseCatalogUuid: firstCatalogUuid,
       licenses: {
         allocated: 10,
         total: 20,
@@ -26,6 +28,7 @@ const defaultProps = {
       title: 'Enterprise B',
       startDate: '2021-03-13',
       expirationDate: '2024-10-13',
+      enterpriseCatalogUuid: 'catalogID2',
       licenses: {
         allocated: 11,
         total: 30,
@@ -53,5 +56,23 @@ describe('MultipleSubscriptionsPicker', () => {
     defaultProps.subscriptions.forEach((subscription) => {
       expect(screen.getByText(subscription.title)).toBeInTheDocument();
     });
+  });
+  it('sets the uuid to the catalog uuid when useCatalog is true', () => {
+    const buttonText = 'Click me!';
+    const { history } = renderWithRouter(
+      <MultipleSubscriptionsPicker {...defaultProps} useCatalog buttonText={buttonText} />,
+    );
+    const button = screen.queryAllByText(buttonText)[0];
+    userEvent.click(button);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${firstCatalogUuid}`);
+  });
+  it('sets the uuid to the enterprise uuid when useCatalog is false', () => {
+    const buttonText = 'Click me!';
+    const { history } = renderWithRouter(
+      <MultipleSubscriptionsPicker {...defaultProps} buttonText={buttonText} />,
+    );
+    const button = screen.queryAllByText(buttonText)[0];
+    userEvent.click(button);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${firstEnterpriseUuid}`);
   });
 });

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
@@ -57,16 +57,7 @@ describe('MultipleSubscriptionsPicker', () => {
       expect(screen.getByText(subscription.title)).toBeInTheDocument();
     });
   });
-  it('sets the uuid to the catalog uuid when useCatalog is true', () => {
-    const buttonText = 'Click me!';
-    const { history } = renderWithRouter(
-      <MultipleSubscriptionsPicker {...defaultProps} useCatalog buttonText={buttonText} />,
-    );
-    const button = screen.queryAllByText(buttonText)[0];
-    userEvent.click(button);
-    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${firstCatalogUuid}`);
-  });
-  it('sets the uuid to the enterprise uuid when useCatalog is false', () => {
+  it('sets the correct url on the button link', () => {
     const buttonText = 'Click me!';
     const { history } = renderWithRouter(
       <MultipleSubscriptionsPicker {...defaultProps} buttonText={buttonText} />,

--- a/src/components/subscriptions/tests/SubscriptionCard.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionCard.test.jsx
@@ -27,25 +27,26 @@ describe('SubscriptionCard', () => {
     renderWithRouter(<SubscriptionCard {...defaultProps} />);
     expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
   });
-
-  it('sets the correct default link', () => {
-    const buttonText = 'click me!';
-    const { history } = renderWithRouter(
-      <SubscriptionCard {...defaultProps} buttonText={buttonText} />,
-    );
-    const button = screen.getByText(buttonText);
-    userEvent.click(button);
-    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${defaultProps.uuid}`);
-  });
-  it('sets the correct link from props', () => {
-    const buttonText = 'click me!';
-    const redirectPage = 'customredirect';
-    const { history } = renderWithRouter(
-      <SubscriptionCard {...defaultProps} buttonText={buttonText} redirectPage={redirectPage} />,
-    );
-    const button = screen.getByText(buttonText);
-    userEvent.click(button);
-    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${redirectPage}/${defaultProps.uuid}`);
+  describe('button link', () => {
+    it('sets the correct default link', () => {
+      const buttonText = 'click me!';
+      const { history } = renderWithRouter(
+        <SubscriptionCard {...defaultProps} buttonText={buttonText} />,
+      );
+      const button = screen.getByText(buttonText);
+      userEvent.click(button);
+      expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${defaultProps.uuid}`);
+    });
+    it('sets the correct link from props, custom redirect', () => {
+      const buttonText = 'click me!';
+      const redirectPage = 'customredirect';
+      const { history } = renderWithRouter(
+        <SubscriptionCard {...defaultProps} buttonText={buttonText} redirectPage={redirectPage} />,
+      );
+      const button = screen.getByText(buttonText);
+      userEvent.click(button);
+      expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${redirectPage}/${defaultProps.uuid}`);
+    });
   });
   describe('button text', () => {
     it('displays text received as a prop', () => {

--- a/src/components/subscriptions/tests/SubscriptionCard.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionCard.test.jsx
@@ -1,0 +1,64 @@
+import {
+  screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+
+import React from 'react';
+import { renderWithRouter } from '../../test/testUtils';
+
+import SubscriptionCard from '../SubscriptionCard';
+
+const defaultProps = {
+  uuid: 'ided',
+  title: 'Select something',
+  enterpriseSlug: 'sluggy',
+  startDate: '2021-04-13',
+  expirationDate: '2024-04-13',
+  licenses: {
+    allocated: 10,
+    total: 20,
+  },
+};
+
+describe('SubscriptionCard', () => {
+  it('displays a title', () => {
+    renderWithRouter(<SubscriptionCard {...defaultProps} />);
+    expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+  });
+
+  it('sets the correct default link', () => {
+    const buttonText = 'click me!';
+    const { history } = renderWithRouter(
+      <SubscriptionCard {...defaultProps} buttonText={buttonText} />,
+    );
+    const button = screen.getByText(buttonText);
+    userEvent.click(button);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/subscriptions/${defaultProps.uuid}`);
+  });
+  it('sets the correct link from props', () => {
+    const buttonText = 'click me!';
+    const redirectPage = 'customredirect';
+    const { history } = renderWithRouter(
+      <SubscriptionCard {...defaultProps} buttonText={buttonText} redirectPage={redirectPage} />,
+    );
+    const button = screen.getByText(buttonText);
+    userEvent.click(button);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${redirectPage}/${defaultProps.uuid}`);
+  });
+  describe('button text', () => {
+    it('displays text received as a prop', () => {
+      const buttonText = 'click me!';
+      renderWithRouter(<SubscriptionCard {...defaultProps} buttonText={buttonText} />);
+      expect(screen.getByText(buttonText)).toBeInTheDocument();
+    });
+    it('displays the correct text if license is not expired', () => {
+      renderWithRouter(<SubscriptionCard {...defaultProps} />);
+      expect(screen.getByText('Manage learners')).toBeInTheDocument();
+    });
+    it('displays the correct text for an expired license', () => {
+      renderWithRouter(<SubscriptionCard {...defaultProps} expirationDate="2021-04-14" />);
+      expect(screen.getByText('View learners')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/subscriptions/tests/SubscriptionCard.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionCard.test.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { renderWithRouter } from '../../test/testUtils';
 
 import SubscriptionCard from '../SubscriptionCard';
+import { DEFAULT_REDIRECT_PAGE } from '../data/constants';
 
 const defaultProps = {
   uuid: 'ided',
@@ -34,7 +35,7 @@ describe('SubscriptionCard', () => {
     );
     const button = screen.getByText(buttonText);
     userEvent.click(button);
-    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/subscriptions/${defaultProps.uuid}`);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${defaultProps.uuid}`);
   });
   it('sets the correct link from props', () => {
     const buttonText = 'click me!';


### PR DESCRIPTION
This feature refactors and uses the MultipleSubscriptionPage that is used for subscription management and uses it on the bulk enrollment page.
With one subscription, users will be redirected automatically. 
With multiple subscriptions, users will be directed to the the page below that allows them to choose their subscription.
The table of courses that users are directed to after redirect / choosing a subscription will now be filtered by that enterprise's subscription.

**Note**: The functionality / text of the original subscription picker (accessed through "Subscription Management" in the nav, should remain unchanged.

![Screen Shot 2021-04-21 at 2 27 09 PM](https://user-images.githubusercontent.com/13922520/115605780-f0a1a000-a2b0-11eb-8e0f-eba1734e0b58.png)

Mobile:
![Screen Shot 2021-04-22 at 8 54 28 AM](https://user-images.githubusercontent.com/13922520/115717665-61e06200-a348-11eb-9072-2a76872ea4e2.png)


