### PR TITLE
feat: add loading state and redirect to pages that depend on the subscription picker

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -12,6 +12,7 @@ import Skeleton from 'react-loading-skeleton';
 import CourseSearchResults from './CourseSearchResults';
 import { configuration } from '../../config';
 import { useSubscriptionFromParams } from '../subscriptions/data/contextHooks';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const searchClient = algoliasearch(
   configuration.ALGOLIA.APP_ID,
@@ -27,7 +28,7 @@ const CourseSearch = ({
   const [subscription, isLoadingSubscription] = useSubscriptionFromParams({ match });
   if (!subscription && !isLoadingSubscription) {
     return (
-      <Redirect to={`/${enterpriseSlug}/admin/catalog-management/`} />
+      <Redirect to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.bulkEnrollment}/`} />
     );
   }
   if (isLoadingSubscription) {

--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -21,7 +21,7 @@ const searchClient = algoliasearch(
 
 export const NO_DATA_MESSAGE = 'There are no results';
 
-const CourseSearch = ({
+export const BaseCourseSearch = ({
   enterpriseId, enterpriseSlug, enterpriseName, match,
 }) => {
   const PAGE_TITLE = `Search courses - ${enterpriseName}`;
@@ -33,10 +33,10 @@ const CourseSearch = ({
   }
   if (isLoadingSubscription) {
     return (
-      <>
+      <div data-testid="skelly">
         <Skeleton height={175} />
         <Skeleton className="mt-3" height={50} count={25} />
-      </>
+      </div>
     );
   }
 
@@ -61,14 +61,14 @@ const CourseSearch = ({
   );
 };
 
-CourseSearch.defaultProps = {
+BaseCourseSearch.defaultProps = {
   enterpriseId: '',
   enterpriseSlug: '',
   enterpriseName: '',
 };
 
-CourseSearch.propTypes = {
-  // from redux-store
+BaseCourseSearch.propTypes = {
+  // from redux store
   enterpriseId: PropTypes.string,
   enterpriseSlug: PropTypes.string,
   enterpriseName: PropTypes.string,
@@ -82,4 +82,4 @@ const mapStateToProps = state => ({
   enterpriseName: state.portalConfiguration.enterpriseName,
 });
 
-export default connect(mapStateToProps)(CourseSearch);
+export default connect(mapStateToProps)(BaseCourseSearch);

--- a/src/components/BulkEnrollmentPage/CourseSearch.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
-
 import algoliasearch from 'algoliasearch/lite';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
+import { Redirect } from 'react-router';
+
 import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import { SearchHeader, SearchData } from '@edx/frontend-enterprise';
+import Skeleton from 'react-loading-skeleton';
+
 import CourseSearchResults from './CourseSearchResults';
 import { configuration } from '../../config';
 import { useSubscriptionFromParams } from '../subscriptions/data/contextHooks';
-import { NotFound } from '../NotFoundPage';
 
 const searchClient = algoliasearch(
   configuration.ALGOLIA.APP_ID,
@@ -22,10 +24,18 @@ const CourseSearch = ({
   enterpriseId, enterpriseSlug, enterpriseName, match,
 }) => {
   const PAGE_TITLE = `Search courses - ${enterpriseName}`;
-  const subscription = useSubscriptionFromParams({ match });
-  if (!subscription) {
+  const [subscription, isLoadingSubscription] = useSubscriptionFromParams({ match });
+  if (!subscription && !isLoadingSubscription) {
     return (
-      <NotFound />
+      <Redirect to={`/${enterpriseSlug}/admin/catalog-management/`} />
+    );
+  }
+  if (isLoadingSubscription) {
+    return (
+      <>
+        <Skeleton height={175} />
+        <Skeleton className="mt-3" height={50} count={25} />
+      </>
     );
   }
 

--- a/src/components/BulkEnrollmentPage/CourseSearch.test.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearch.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { useSubscriptionFromParams } from '../subscriptions/data/contextHooks';
+import { BaseCourseSearch } from './CourseSearch';
+import { renderWithRouter } from '../test/testUtils';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
+
+jest.mock('react-instantsearch-dom', () => ({
+  ...jest.requireActual('react-instantsearch-dom'),
+  InstantSearch: () => <div>INSTANTLY SEARCH</div>,
+}));
+
+jest.mock('../subscriptions/data/contextHooks', () => ({
+  useSubscriptionFromParams: jest.fn(),
+}));
+
+const defaultProps = {
+  enterpriseId: 'foo',
+  enterpriseSlug: 'fancyCompany',
+  enterpriseName: 'So Fancy',
+  match: {},
+};
+
+const fakeSubscription = {
+  enterpriseCatalogUuid: 'bestCatalog',
+};
+
+describe('<BaseCourseSearch />', () => {
+  it('renders the instant search component', () => {
+    useSubscriptionFromParams.mockReturnValue([fakeSubscription, false]);
+    renderWithRouter(<BaseCourseSearch {...defaultProps} />);
+    screen.getByText('INSTANTLY SEARCH');
+  });
+  it('shows a loading screen ', () => {
+    useSubscriptionFromParams.mockReturnValue([null, true]);
+    renderWithRouter(<BaseCourseSearch {...defaultProps} />);
+    expect(screen.getByTestId('skelly')).toBeInTheDocument();
+  });
+  it('redirects to the subscription choosing page if there is no subscription', () => {
+    useSubscriptionFromParams.mockReturnValue([null, false]);
+    const { history } = renderWithRouter(<BaseCourseSearch {...defaultProps} />);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${ROUTE_NAMES.bulkEnrollment}/`);
+  });
+});

--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -7,6 +7,7 @@ import { Switch, Route } from 'react-router-dom';
 import Hero from '../Hero';
 import { MultipleSubscriptionsPage, SubscriptionData } from '../subscriptions';
 import CourseSearch from './CourseSearch';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 function BulkEnrollmentPage({ enterpriseId }) {
   return (
@@ -16,12 +17,12 @@ function BulkEnrollmentPage({ enterpriseId }) {
         <main role="main" className="manage-subscription">
           <Switch>
             <Route
-              path="/:enterpriseSlug/admin/catalog-management"
+              path={`/:enterpriseSlug/admin/${ROUTE_NAMES.bulkEnrollment}`}
               component={routeProps => (
                 <Container className="py-3" fluid>
                   <MultipleSubscriptionsPage
                     {...routeProps}
-                    redirectPage="catalog-management"
+                    redirectPage={ROUTE_NAMES.bulkEnrollment}
                     useCatalog
                     leadText="Choose a subscription to enroll your learners in courses"
                     buttonText="Enroll learners"
@@ -31,7 +32,7 @@ function BulkEnrollmentPage({ enterpriseId }) {
               exact
             />
             <Route
-              path="/:enterpriseSlug/admin/catalog-management/:subscriptionUUID"
+              path={`/:enterpriseSlug/admin/${ROUTE_NAMES.bulkEnrollment}/:subscriptionUUID`}
               component={CourseSearch}
               exact
             />

--- a/src/components/EnterpriseApp/constants.js
+++ b/src/components/EnterpriseApp/constants.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+
+export const ROUTE_NAMES = {
+  bulkEnrollment: 'catalog-management',
+  subscriptionManagement: 'subscriptions',
+};

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -196,7 +196,7 @@ class EnterpriseApp extends React.Component {
                   {enableSubscriptionManagementScreen && (
                     <Route
                       key="subscription-management"
-                      path={`${baseUrl}/admin/subscriptions`}
+                      path={`${baseUrl}/admin/${ROUTE_NAMES.subscriptionManagement}`}
                       render={routeProps => <SubscriptionManagementPage {...routeProps} />}
                     />
                   )}

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -21,6 +21,7 @@ import { AnalyticsPage } from '../analytics';
 import { removeTrailingSlash } from '../../utils';
 import { features } from '../../config';
 import LmsConfigurations from '../../containers/LmsConfigurations';
+import { ROUTE_NAMES } from './constants';
 
 class EnterpriseApp extends React.Component {
   constructor(props) {
@@ -176,8 +177,8 @@ class EnterpriseApp extends React.Component {
                   {(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen)
                     && (
                     <Route
-                      key="catalog-management"
-                      path={`${baseUrl}/admin/catalog-management`}
+                      key={ROUTE_NAMES.bulkEnrollment}
+                      path={`${baseUrl}/admin/${ROUTE_NAMES.bulkEnrollment}`}
                       render={routeProps => <BulkEnrollmentPage {...routeProps} />}
                     />
                     )}

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -10,6 +10,7 @@ import {
 import IconLink from './IconLink';
 
 import { features } from '../../config';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 class Sidebar extends React.Component {
   constructor(props) {
@@ -91,7 +92,7 @@ class Sidebar extends React.Component {
       },
       {
         title: 'Catalog Management',
-        to: `${baseUrl}/admin/catalog-management`,
+        to: `${baseUrl}/admin/${ROUTE_NAMES.bulkEnrollment}`,
         icon: faBookOpen,
         hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),
       },

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -7,7 +7,8 @@ import {
 } from '@edx/paragon';
 
 import SubscriptionCard from './SubscriptionCard';
-import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from './data/constants';
+import { DEFAULT_LEAD_TEXT } from './data/constants';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const MultipleSubscriptionsPicker = ({
   enterpriseSlug, leadText, buttonText, redirectPage, subscriptions,
@@ -40,7 +41,7 @@ const MultipleSubscriptionsPicker = ({
 );
 
 MultipleSubscriptionsPicker.defaultProps = {
-  redirectPage: DEFAULT_REDIRECT_PAGE,
+  redirectPage: ROUTE_NAMES.subscriptionManagement,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,
 };

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -6,7 +6,8 @@ import { SubscriptionContext } from './SubscriptionData';
 
 import SubscriptionExpiration from './expiration/SubscriptionExpiration';
 import MultipleSubscriptionsPicker from './MultipleSubscriptionPicker';
-import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from './data/constants';
+import { DEFAULT_LEAD_TEXT } from './data/constants';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const MultipleSubscriptionsPage = ({
   match, redirectPage, leadText, buttonText,
@@ -40,7 +41,7 @@ const MultipleSubscriptionsPage = ({
 };
 
 MultipleSubscriptionsPage.defaultProps = {
-  redirectPage: DEFAULT_REDIRECT_PAGE,
+  redirectPage: ROUTE_NAMES.subscriptionManagement,
   leadText: DEFAULT_LEAD_TEXT,
   buttonText: null,
 };

--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { Card, Badge, Button } from '@edx/paragon';
-import { DEFAULT_REDIRECT_PAGE } from './data/constants';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const SubscriptionCard = ({
   uuid,
@@ -58,7 +58,7 @@ const SubscriptionCard = ({
 };
 
 SubscriptionCard.defaultProps = {
-  redirectPage: DEFAULT_REDIRECT_PAGE,
+  redirectPage: ROUTE_NAMES.subscriptionManagement,
   buttonText: null,
 };
 

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -12,6 +12,7 @@ export default function SubscriptionData({ children, enterpriseId }) {
     errors,
     setErrors,
     forceRefresh,
+    loading,
   } = useSubscriptionData({ enterpriseId });
   const hasSubscription = subscriptions?.length > 0;
 
@@ -20,7 +21,8 @@ export default function SubscriptionData({ children, enterpriseId }) {
     errors,
     setErrors,
     forceRefresh,
-  }), [subscriptions, errors]);
+    loading,
+  }), [subscriptions, errors, loading]);
 
   if (subscriptions) {
     return (

--- a/src/components/subscriptions/SubscriptionDetailPage.jsx
+++ b/src/components/subscriptions/SubscriptionDetailPage.jsx
@@ -8,12 +8,19 @@ import SubscriptionDetailContextProvider from './SubscriptionDetailContextProvid
 import { useSubscriptionFromParams } from './data/contextHooks';
 
 import { NotFound } from '../NotFoundPage';
+import SubscriptionDetailsSkeleton from './SubscriptionDetailsSkeleton';
 
 const SubscriptionDetailPage = ({ match }) => {
-  const subscription = useSubscriptionFromParams({ match });
-  if (!subscription) {
+  const [subscription, loadingSubscription] = useSubscriptionFromParams({ match });
+  if (!subscription && !loadingSubscription) {
     return (
       <NotFound />
+    );
+  }
+
+  if (loadingSubscription) {
+    return (
+      <SubscriptionDetailsSkeleton />
     );
   }
   return (

--- a/src/components/subscriptions/SubscriptionDetailPage.jsx
+++ b/src/components/subscriptions/SubscriptionDetailPage.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Redirect } from 'react-router-dom';
+
 import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBanner';
 import SubscriptionExpirationModal from './expiration/SubscriptionExpirationModal';
 import SubscriptionDetails from './SubscriptionDetails';
@@ -7,20 +9,22 @@ import LicenseAllocationDetails from './licenses/LicenseAllocationDetails';
 import SubscriptionDetailContextProvider from './SubscriptionDetailContextProvider';
 import { useSubscriptionFromParams } from './data/contextHooks';
 
-import { NotFound } from '../NotFoundPage';
 import SubscriptionDetailsSkeleton from './SubscriptionDetailsSkeleton';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const SubscriptionDetailPage = ({ match }) => {
   const [subscription, loadingSubscription] = useSubscriptionFromParams({ match });
   if (!subscription && !loadingSubscription) {
+    const { params: { enterpriseSlug } } = match;
+
     return (
-      <NotFound />
+      <Redirect to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.subscriptionManagement}/`} />
     );
   }
 
   if (loadingSubscription) {
     return (
-      <SubscriptionDetailsSkeleton />
+      <SubscriptionDetailsSkeleton data-testid="skelly" />
     );
   }
   return (
@@ -37,6 +41,7 @@ SubscriptionDetailPage.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       subscriptionUUID: PropTypes.string.isRequired,
+      enterpriseSlug: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
 };

--- a/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
+++ b/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
@@ -4,8 +4,8 @@ import Skeleton from 'react-loading-skeleton';
 const tableRowHeight = 50;
 const tableRowCount = 10;
 
-const SubscriptionDetailsSkeleton = () => (
-  <>
+const SubscriptionDetailsSkeleton = (props) => (
+  <div {...props}>
     <Skeleton height={175} />
     <Skeleton height={175} />
     <div className="d-md-flex">
@@ -16,7 +16,7 @@ const SubscriptionDetailsSkeleton = () => (
         <Skeleton height={tableRowHeight} count={tableRowCount} />
       </div>
     </div>
-  </>
+  </div>
 );
 
 export default SubscriptionDetailsSkeleton;

--- a/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
+++ b/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+const tableRowHeight = 50;
+const tableRowCount = 10;
+
+const SubscriptionDetailsSkeleton = () => (
+  <>
+    <Skeleton height={175} />
+    <Skeleton height={175} />
+    <div className="d-md-flex">
+      <div className="w-100 w-md-25">
+        <Skeleton height={tableRowCount * tableRowHeight + 45} />
+      </div>
+      <div className="w-100 w-md-75">
+        <Skeleton height={tableRowHeight} count={tableRowCount} />
+      </div>
+    </div>
+  </>
+);
+
+export default SubscriptionDetailsSkeleton;

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -9,6 +9,7 @@ import Hero from '../Hero';
 import SubscriptionData from './SubscriptionData';
 import MultipleSubscriptionsPage from './MultipleSubscriptionsPage';
 import SubscriptionDetailPage from './SubscriptionDetailPage';
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 
 const PAGE_TITLE = 'Subscription Management';
 
@@ -21,12 +22,12 @@ function SubscriptionManagementPage({ enterpriseId }) {
         <Container className="py-3" fluid>
           <Switch>
             <Route
-              path="/:enterpriseSlug/admin/subscriptions"
+              path={`/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}`}
               component={MultipleSubscriptionsPage}
               exact
             />
             <Route
-              path="/:enterpriseSlug/admin/subscriptions/:subscriptionUUID"
+              path={`/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}/:subscriptionUUID`}
               component={SubscriptionDetailPage}
               exact
             />

--- a/src/components/subscriptions/data/constants.js
+++ b/src/components/subscriptions/data/constants.js
@@ -38,4 +38,3 @@ export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration
 
 // Multiple subscription picker
 export const DEFAULT_LEAD_TEXT = 'Invite your learners to access your course catalog and manage your subscription cohorts';
-export const DEFAULT_REDIRECT_PAGE = 'subscriptions';

--- a/src/components/subscriptions/data/contextHooks.jsx
+++ b/src/components/subscriptions/data/contextHooks.jsx
@@ -10,10 +10,10 @@ import { SubscriptionContext } from '../SubscriptionData';
 export const useSubscriptionFromParams = ({ match }) => {
   // Use UUID to find matching subscription plan in SubscriptionContext, return 404 if not found
   const { params: { subscriptionUUID } } = match;
-  const { data: subscriptions } = useContext(SubscriptionContext);
+  const { data: subscriptions, loading } = useContext(SubscriptionContext);
   const enterpriseSubscriptions = Object.values(subscriptions.results).filter(sub => sub.uuid === subscriptionUUID);
   if (!subscriptions.count || enterpriseSubscriptions.length < 1) {
-    return null;
+    return [null, loading];
   }
-  return enterpriseSubscriptions[0];
+  return [enterpriseSubscriptions[0], loading];
 };

--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { camelCaseObject } from '@edx/frontend-platform/utils';
@@ -26,7 +26,9 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
     setSubscriptions({ ...subscriptions });
   };
 
-  useMemo((page = 1) => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect((page = 1) => {
     LicenseManagerApiService.fetchSubscriptions({ enterprise_customer_uuid: enterpriseId, page })
       .then((response) => {
         const { data: subscriptionsData } = camelCaseObject(response);
@@ -38,12 +40,15 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
           ...errors,
           [SUBSCRIPTIONS]: NETWORK_ERROR_MESSAGE,
         });
+      }).finally(() => {
+        setLoading(false);
       });
   }, [enterpriseId]);
 
   return {
     subscriptions,
     forceRefresh,
+    loading,
   };
 };
 
@@ -144,6 +149,7 @@ export const useSubscriptionData = ({ enterpriseId }) => {
   const {
     subscriptions,
     forceRefresh,
+    loading,
   } = useSubscriptions({ enterpriseId, errors, setErrors });
 
   return {
@@ -151,5 +157,6 @@ export const useSubscriptionData = ({ enterpriseId }) => {
     errors,
     setErrors,
     forceRefresh,
+    loading,
   };
 };

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
@@ -9,7 +9,7 @@ import thunk from 'redux-thunk';
 import React from 'react';
 import { renderWithRouter } from '../../test/testUtils';
 import { SubscriptionContext } from '../SubscriptionData';
-import { DEFAULT_REDIRECT_PAGE } from '../data/constants';
+import { ROUTE_NAMES } from '../../EnterpriseApp/constants';
 
 import MultipleSubscriptionsPage from '../MultipleSubscriptionsPage';
 
@@ -73,16 +73,16 @@ const MultipleSubscriptionsPageWrapper = ({ subscriptions = defaultSubscriptions
 describe('MultipleSubscriptionsPage', () => {
   it('displays a the MultipleSubscriptionPicker when there are multiple subscriptions', () => {
     renderWithRouter(<MultipleSubscriptionsPageWrapper {...defaultProps} />, {
-      route: `/${fakeSlug}/admin/subscriptions/`,
-      path: '/:enterpriseSlug/admin/subscriptions/',
+      route: `/${fakeSlug}/admin/${ROUTE_NAMES.subscriptionManagement}`,
+      path: `/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}`,
     });
     expect(screen.getByText('Cohorts')).toBeInTheDocument();
   });
   it('returns null if there are no subscriptions', () => {
     const subscriptions = { data: { results: [] } };
     renderWithRouter(<MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} />, {
-      route: `/${fakeSlug}/admin/subscriptions/`,
-      path: '/:enterpriseSlug/admin/subscriptions/',
+      route: `/${fakeSlug}/admin/${ROUTE_NAMES.subscriptionManagement}`,
+      path: `/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}`,
     });
     expect(screen.queryByText('Cohorts')).not.toBeInTheDocument();
   });
@@ -105,11 +105,11 @@ describe('MultipleSubscriptionsPage', () => {
     const { history } = renderWithRouter(
       <MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} />,
       {
-        route: `/${fakeSlug}/admin/subscriptions/`,
-        path: '/:enterpriseSlug/admin/subscriptions/',
+        route: `/${fakeSlug}/admin/${ROUTE_NAMES.subscriptionManagement}`,
+        path: `/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}`,
       },
     );
-    expect(history.location.pathname).toEqual(`/${fakeSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${subsUuid}`);
+    expect(history.location.pathname).toEqual(`/${fakeSlug}/admin/${ROUTE_NAMES.subscriptionManagement}/${subsUuid}`);
   });
   it('redirects if there is only one subscription, custom redirect page', () => {
     const redirectPage = 'bulkenrollment';
@@ -131,8 +131,8 @@ describe('MultipleSubscriptionsPage', () => {
     const { history } = renderWithRouter(
       <MultipleSubscriptionsPageWrapper subscriptions={subscriptions} {...defaultProps} redirectPage={redirectPage} />,
       {
-        route: `/${fakeSlug}/admin/subscriptions/`,
-        path: '/:enterpriseSlug/admin/subscriptions/',
+        route: `/${fakeSlug}/admin/${ROUTE_NAMES.subscriptionManagement}`,
+        path: `/:enterpriseSlug/admin/${ROUTE_NAMES.subscriptionManagement}`,
       },
     );
     expect(history.location.pathname).toEqual(`/${fakeSlug}/admin/${redirectPage}/${subsUuid}`);

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPicker.test.jsx
@@ -3,9 +3,10 @@ import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../test/testUtils';
-import { DEFAULT_LEAD_TEXT, DEFAULT_REDIRECT_PAGE } from '../data/constants';
+import { DEFAULT_LEAD_TEXT } from '../data/constants';
 
 import MultipleSubscriptionsPicker from '../MultipleSubscriptionPicker';
+import { ROUTE_NAMES } from '../../EnterpriseApp/constants';
 
 const firstCatalogUuid = 'catalogID1';
 const firstEnterpriseUuid = 'ided';
@@ -64,6 +65,6 @@ describe('MultipleSubscriptionsPicker', () => {
     );
     const button = screen.queryAllByText(buttonText)[0];
     userEvent.click(button);
-    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${firstEnterpriseUuid}`);
+    expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${ROUTE_NAMES.subscriptionManagement}/${firstEnterpriseUuid}`);
   });
 });

--- a/src/components/subscriptions/tests/SubscriptionCard.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionCard.test.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { renderWithRouter } from '../../test/testUtils';
 
 import SubscriptionCard from '../SubscriptionCard';
-import { DEFAULT_REDIRECT_PAGE } from '../data/constants';
+import { ROUTE_NAMES } from '../../EnterpriseApp/constants';
 
 const defaultProps = {
   uuid: 'ided',
@@ -35,7 +35,7 @@ describe('SubscriptionCard', () => {
       );
       const button = screen.getByText(buttonText);
       userEvent.click(button);
-      expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${DEFAULT_REDIRECT_PAGE}/${defaultProps.uuid}`);
+      expect(history.location.pathname).toEqual(`/${defaultProps.enterpriseSlug}/admin/${ROUTE_NAMES.subscriptionManagement}/${defaultProps.uuid}`);
     });
     it('sets the correct link from props, custom redirect', () => {
       const buttonText = 'click me!';

--- a/src/components/subscriptions/tests/SubscriptionDetailPage.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionDetailPage.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { useSubscriptionFromParams } from '../data/contextHooks';
+import SubscriptionDetailPage from '../SubscriptionDetailPage';
+import { renderWithRouter } from '../../test/testUtils';
+import { ROUTE_NAMES } from '../../EnterpriseApp/constants';
+
+jest.mock('../SubscriptionDetailContextProvider', () => ({
+  __esModule: true,
+  default: () => <div>SUBSCRIPTION DEETS</div>,
+}));
+
+jest.mock('../data/contextHooks', () => ({
+  useSubscriptionFromParams: jest.fn(),
+}));
+
+const defaultProps = {
+  match: {
+    params: {
+      enterpriseSlug: 'sluggy',
+      subscriptionUUID: 'uuid-ed',
+    },
+  },
+};
+
+const fakeSubscription = {};
+
+describe('<SubscriptionDetailPage />', () => {
+  it('renders the instant search component', () => {
+    useSubscriptionFromParams.mockReturnValue([fakeSubscription, false]);
+    renderWithRouter(<SubscriptionDetailPage {...defaultProps} />);
+    screen.getByText('SUBSCRIPTION DEETS');
+  });
+  it('shows a loading screen ', () => {
+    useSubscriptionFromParams.mockReturnValue([null, true]);
+    renderWithRouter(<SubscriptionDetailPage {...defaultProps} />);
+    expect(screen.getByTestId('skelly')).toBeInTheDocument();
+  });
+  it('redirects to the subscription choosing page if there is no subscription', () => {
+    useSubscriptionFromParams.mockReturnValue([null, false]);
+    const { history } = renderWithRouter(<SubscriptionDetailPage {...defaultProps} />);
+    expect(history.location.pathname).toEqual(`/${defaultProps.match.params.enterpriseSlug}/admin/${ROUTE_NAMES.subscriptionManagement}/`);
+  });
+});


### PR DESCRIPTION
Instead of flashing a 404 while we are loading data, this adds a loading state and loading skeleton to the CourseSearch and SubscriptionDetailsPage

In addition, instead of showing a 404 when the subscription cannot be found, the user is redirected back to the subscription picker (or to their one subscription if they only have one.)

Also changes the route names for these two routes to constants because my constant misspelling of `managment` made my tests fail until I got frustrated enough to make it never happen again.

Skeleton catalog management mobile:
![Screen Shot 2021-04-23 at 10 39 51 AM](https://user-images.githubusercontent.com/13922520/115887836-52344c80-a420-11eb-870c-1942f866652b.png)

Skeleton subs management mobile:
![Screen Shot 2021-04-23 at 10 39 39 AM](https://user-images.githubusercontent.com/13922520/115887930-64ae8600-a420-11eb-81af-0b37500c953c.png)

Desktop catalog management:
![Screen Shot 2021-04-23 at 10 38 36 AM](https://user-images.githubusercontent.com/13922520/115887970-6ed08480-a420-11eb-891a-3e0d6ced7582.png)

Desktop subs management:
![Screen Shot 2021-04-23 at 10 38 24 AM](https://user-images.githubusercontent.com/13922520/115888025-7859ec80-a420-11eb-9d75-4a540836e334.png)
