### PR TITLE
style: rename Bulk Enrollment titles and endpoints

### DIFF
--- a/src/components/BulkEnrollmentPage/index.jsx
+++ b/src/components/BulkEnrollmentPage/index.jsx
@@ -12,7 +12,7 @@ import { ROUTE_NAMES } from '../EnterpriseApp/constants';
 function BulkEnrollmentPage({ enterpriseId }) {
   return (
     <div className="container-fluid bulk-enrollment">
-      <Hero title="Catalog Management" />
+      <Hero title="Subscription Enrollment" />
       <SubscriptionData enterpriseId={enterpriseId}>
         <main role="main" className="manage-subscription">
           <Switch>

--- a/src/components/EnterpriseApp/constants.js
+++ b/src/components/EnterpriseApp/constants.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
 export const ROUTE_NAMES = {
-  bulkEnrollment: 'catalog-management',
+  bulkEnrollment: 'enrollment',
   subscriptionManagement: 'subscriptions',
 };

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -91,7 +91,7 @@ class Sidebar extends React.Component {
         hidden: !features.SAML_CONFIGURATION || !enableSamlConfigurationScreen,
       },
       {
-        title: 'Catalog Management',
+        title: 'Subscription Enrollment',
         to: `${baseUrl}/admin/${ROUTE_NAMES.bulkEnrollment}`,
         icon: faBookOpen,
         hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),


### PR DESCRIPTION
- Renames the bulk enrollment endpoint path from `catalog-management` to `enrollment`
- Renames the titles in a few spots (ie wherever it was present) from "Catalog Management" to "Subscription Enrollment"