### PR TITLE
fix: enrollment - open course link in new tab

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearchResultsCells.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResultsCells.jsx
@@ -6,7 +6,13 @@ import moment from 'moment';
 import { configuration } from '../../config';
 
 export const CourseNameCell = ({ value, row, enterpriseSlug }) => (
-  <a href={`${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}/course/${row?.original?.key}`}>{value}</a>
+  <a
+    href={`${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}/course/${row?.original?.key}`}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {value}
+  </a>
 );
 
 CourseNameCell.propTypes = {


### PR DESCRIPTION
On the Subscription Enrollment screen, we want course links to open a new tab.

As a heads up for people who may also copy the rel tags from our other codebases/stack overflow, here's what those actually do:

noreferrer:
- conceals where traffic to a new site is coming from (aka the referring page)

noopener:
- disables the JS window.opener property (this JS property gives the pages linked to partial control over content of the referring page which we do not want)