### PR TITLE
maint: adding success and failure handling to the new bulk enrollment

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connectStateResults } from 'react-instantsearch-dom';
 import Skeleton from 'react-loading-skeleton';
 import {
-  DataTable, /* Toast, */ Button,
+  DataTable, Button,
 } from '@edx/paragon';
 import { SearchContext, SearchPagination } from '@edx/frontend-enterprise';
 
@@ -107,7 +107,6 @@ export const BaseCourseSearchResults = (props) => {
     [searchState?.page, refinementsFromQueryParams],
   );
 
-  // const [showToast, setShowToast] = useState(false);
   const { courses: [selectedCourses, coursesDispatch] } = useContext(BulkEnrollContext);
 
   if (isSearchStalled) {
@@ -140,14 +139,6 @@ export const BaseCourseSearchResults = (props) => {
 
   return (
     <>
-      {/* TODO: Update toast when stepper is complete to show the enrollment message.
-        And/or use the existing toast framework */}
-      {/* <Toast
-        onClose={() => setShowToast(false)}
-        show={showToast}
-      >
-        {`${enrolledLearners} learners have been enrolled.`}
-      </Toast> */}
       <DataTable
         columns={columns}
         data={searchResults?.hits || []}

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Stepper, Button, Container,
@@ -7,7 +7,9 @@ import AddCoursesStep from './AddCoursesStep';
 import AddLearnersStep from './AddLearnersStep';
 import ReviewStep from './ReviewStep';
 import {
-  NEXT_BUTTON_TEXT, PREVIOUS_BUTTON_TEXT, FINAL_BUTTON_TEXT, PREV_BUTTON_TEST_ID, FINAL_BUTTON_TEST_ID,
+  PREV_BUTTON_TEST_ID,
+  NEXT_BUTTON_TEXT,
+  PREVIOUS_BUTTON_TEXT,
   NEXT_BUTTON_TEST_ID,
   ADD_LEARNERS_STEP,
   REVIEW_STEP,
@@ -17,12 +19,12 @@ import {
   REVIEW_TITLE,
 } from './constants';
 import { BulkEnrollContext } from '../BulkEnrollmentContext';
+import BulkEnrollmentSubmit from './BulkEnrollmentSubmit';
 
 const BulkEnrollmentStepper = ({ subscription, enterpriseSlug, enterpriseId }) => {
   const steps = [ADD_COURSES_STEP, ADD_LEARNERS_STEP, REVIEW_STEP];
   const [currentStep, setCurrentStep] = useState(steps[0]);
   const { emails: [selectedEmails], courses: [selectedCourses] } = useContext(BulkEnrollContext);
-  const hasSelectedCoursesAndEmails = selectedEmails.length > 0 && selectedCourses.length > 0;
 
   return (
     <Stepper activeKey={currentStep}>
@@ -87,12 +89,11 @@ const BulkEnrollmentStepper = ({ subscription, enterpriseSlug, enterpriseId }) =
               {PREVIOUS_BUTTON_TEXT}
             </Button>
             <Stepper.ActionRow.Spacer />
-            <Button
-              disabled={!hasSelectedCoursesAndEmails}
-              data-testid={FINAL_BUTTON_TEST_ID}
-            >
-              {FINAL_BUTTON_TEXT}
-            </Button>
+            <BulkEnrollmentSubmit
+              enterpriseId={enterpriseId}
+              enterpriseSlug={enterpriseSlug}
+              returnToInitialStep={() => setCurrentStep(ADD_COURSES_STEP)}
+            />
           </Stepper.ActionRow>
         </Container>
       </div>

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.test.jsx
@@ -14,6 +14,7 @@ import BulkEnrollContextProvider from '../BulkEnrollmentContext';
 
 import '../../../../__mocks__/react-instantsearch-dom';
 import { renderWithRouter } from '../../test/testUtils';
+import { ToastsContext } from '../../Toasts/ToastsProvider';
 
 jest.mock('../../subscriptions/data/hooks', () => ({
   useAllSubscriptionUsers: jest.fn(),
@@ -32,10 +33,14 @@ const defaultProps = {
   subscription: { uuid: 'fakest-uuid', enterpriseName: 'fakeCo', enterpriseCatalogUuid: '12345' },
 };
 
+const addToast = jest.fn();
+
 const StepperWrapper = (props) => (
-  <BulkEnrollContextProvider>
-    <BulkEnrollmentStepper {...props} />
-  </BulkEnrollContextProvider>
+  <ToastsContext.Provider value={{ addToast }}>
+    <BulkEnrollContextProvider>
+      <BulkEnrollmentStepper {...props} />
+    </BulkEnrollContextProvider>
+  </ToastsContext.Provider>
 );
 
 const navigateToAddLearners = () => {

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
@@ -1,0 +1,129 @@
+import React, {
+  useContext,
+  useState,
+} from 'react';
+import {
+  Button, Form, AlertModal, Hyperlink, ActionRow, useToggle,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import { logError } from '@edx/frontend-platform/logging';
+import {
+  FINAL_BUTTON_TEST_ID,
+  FINAL_BUTTON_TEXT,
+  NOTIFY_CHECKBOX_TEST_ID,
+  CUSTOMER_SUPPORT_HYPERLINK_TEST_ID,
+  ALERT_MODAL_TITLE_TEXT,
+  ALERT_MODAL_BODY_TEXT,
+  SUPPORT_HYPERLINK_TEXT,
+} from './constants';
+import LicenseManagerApiService from '../../../data/services/LicenseManagerAPIService';
+import { BulkEnrollContext } from '../BulkEnrollmentContext';
+import { ToastsContext } from '../../Toasts';
+import { clearSelectionAction } from '../data/actions';
+
+export const BulkEnrollmentAlertModal = ({ isOpen, toggleClose, enterpriseSlug }) => (
+  <AlertModal
+    title={ALERT_MODAL_TITLE_TEXT}
+    isOpen={isOpen}
+    onClose={toggleClose}
+    footerNode={(
+      <ActionRow>
+        <Button variant="primary" onClick={toggleClose}>OK</Button>
+      </ActionRow>
+    )}
+  >
+    <p>
+      {ALERT_MODAL_BODY_TEXT}
+      <Hyperlink
+        destination={`/${enterpriseSlug}/admin/support`}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid={CUSTOMER_SUPPORT_HYPERLINK_TEST_ID}
+      >
+        {SUPPORT_HYPERLINK_TEXT}
+      </Hyperlink>
+    </p>
+  </AlertModal>
+);
+
+BulkEnrollmentAlertModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggleClose: PropTypes.func.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
+};
+
+export const generateSuccessMessage = numEmails => `${numEmails} learners have been enrolled.`;
+
+const BulkEnrollmentSubmit = ({ enterpriseId, enterpriseSlug, returnToInitialStep }) => {
+  const [loading, setLoading] = useState(false);
+  const [checked, setChecked] = useState(true);
+  const handleChange = e => setChecked(e.target.checked);
+
+  const {
+    emails: [selectedEmails, emailsDispatch],
+    courses: [selectedCourses, coursesDispatch],
+  } = useContext(BulkEnrollContext);
+  const { addToast } = useContext(ToastsContext);
+
+  const courseKeys = selectedCourses.map(
+    ({ original, id }) => original?.advertised_course_run?.key || id,
+  );
+  const emails = selectedEmails.map(({ values }) => values.userEmail);
+  const [isErrorModalOpen, toggleErrorModalOpen, toggleErrorModalClose] = useToggle();
+  const hasSelectedCoursesAndEmails = selectedEmails.length > 0 && selectedCourses.length > 0;
+
+  const submitBulkEnrollment = () => {
+    setLoading(true);
+    const options = {
+      emails,
+      course_run_keys: courseKeys,
+      notify: checked,
+    };
+
+    return LicenseManagerApiService.licenseBulkEnroll(
+      enterpriseId,
+      options,
+    ).then(() => {
+      coursesDispatch(clearSelectionAction());
+      emailsDispatch(clearSelectionAction());
+      addToast(generateSuccessMessage(selectedEmails.length));
+      returnToInitialStep();
+    }).catch((err) => {
+      logError(err);
+      toggleErrorModalOpen();
+      setLoading(false);
+    });
+  };
+
+  return (
+    <>
+      <BulkEnrollmentAlertModal
+        enterpriseSlug={enterpriseSlug}
+        toggleClose={toggleErrorModalClose}
+        isOpen={isErrorModalOpen}
+      />
+      <Form.Checkbox
+        checked={checked}
+        onChange={handleChange}
+        data-testid={NOTIFY_CHECKBOX_TEST_ID}
+      >
+        Notify learners
+      </Form.Checkbox>
+      <Button
+        disabled={!hasSelectedCoursesAndEmails && !loading}
+        onClick={submitBulkEnrollment}
+        data-testid={FINAL_BUTTON_TEST_ID}
+      >
+        {FINAL_BUTTON_TEXT}
+      </Button>
+    </>
+  );
+};
+
+BulkEnrollmentSubmit.propTypes = {
+  enterpriseId: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
+  returnToInitialStep: PropTypes.func.isRequired,
+};
+
+export default BulkEnrollmentSubmit;

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
@@ -1,0 +1,341 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { logError } from '@edx/frontend-platform/logging';
+import BulkEnrollmentSubmit, {
+  BulkEnrollmentAlertModal,
+  generateSuccessMessage,
+} from './BulkEnrollmentSubmit';
+import {
+  NOTIFY_CHECKBOX_TEST_ID,
+  FINAL_BUTTON_TEST_ID,
+  CUSTOMER_SUPPORT_HYPERLINK_TEST_ID,
+  ALERT_MODAL_TITLE_TEXT,
+} from './constants';
+import { BulkEnrollContext } from '../BulkEnrollmentContext';
+import { clearSelectionAction } from '../data/actions';
+import { ToastsContext } from '../../Toasts/ToastsProvider';
+import { renderWithRouter } from '../../test/testUtils';
+import LicenseManagerApiService from '../../../data/services/LicenseManagerAPIService';
+
+jest.mock('../../../data/services/LicenseManagerAPIService', () => ({
+  __esModule: true, // this property makes it work
+  default: {
+    licenseBulkEnroll: jest.fn(),
+  },
+}));
+
+const defaultProps = {
+  enterpriseId: 'abc1234z-53c9-4071-b698-b8d436eb0295',
+  enterpriseSlug: 'test-enterprise',
+  returnToInitialStep: jest.fn(),
+};
+const defaultAlertProps = {
+  isOpen: true,
+  toggleClose: jest.fn(),
+  enterpriseSlug: 'test-enterprise',
+};
+
+const emailsDispatch = jest.fn();
+const coursesDispatch = jest.fn();
+
+const defaultBulkEnrollInfo = {
+  emails: [[], emailsDispatch],
+  courses: [[], coursesDispatch],
+};
+
+const userEmails = ['ayy', 'lmao'];
+const courseNames = ['Alex', 'Lael'];
+
+const selectedEmails = userEmails.map(
+  (email, index) => ({ id: index, values: { userEmail: email } }),
+);
+const selectedCourses = courseNames.map(
+  (course) => ({ id: course }),
+);
+const bulkEnrollWithAllSelectedRows = {
+  emails: [selectedEmails, emailsDispatch],
+  courses: [selectedCourses, coursesDispatch],
+};
+const bulkEnrollWithEmailsSelectedRows = {
+  emails: [selectedEmails, emailsDispatch],
+  courses: [[], coursesDispatch],
+};
+const bulkEnrollWithCoursesSelectedRows = {
+  emails: [[], emailsDispatch],
+  courses: [selectedCourses, coursesDispatch],
+};
+const addToast = jest.fn();
+
+// eslint-disable-next-line react/prop-types
+const BulkEnrollmentSubmitWrapper = ({ bulkEnrollInfo = defaultBulkEnrollInfo, ...props }) => (
+  <ToastsContext.Provider value={{ addToast }}>
+    <BulkEnrollContext.Provider value={bulkEnrollInfo}>
+      <BulkEnrollmentSubmit {...props} />
+    </BulkEnrollContext.Provider>
+  </ToastsContext.Provider>
+);
+
+describe('BulkEnrollmentAlertModal', () => {
+  beforeEach(() => {
+    defaultAlertProps.toggleClose.mockClear();
+  });
+
+  it('renders an alert', () => {
+    render(<BulkEnrollmentAlertModal {...defaultAlertProps} />);
+    expect(screen.getByText(ALERT_MODAL_TITLE_TEXT)).toBeInTheDocument();
+  });
+
+  // TODO find out how to test hyperlinks that open in new windows
+  it.skip('links to support', async () => {
+    const { history } = renderWithRouter(
+      <BulkEnrollmentAlertModal {...defaultAlertProps} />,
+      {
+        route: '/',
+        path: '/',
+      },
+    );
+    /* click link */
+    const supportLink = screen.getByTestId(CUSTOMER_SUPPORT_HYPERLINK_TEST_ID);
+    await userEvent.click(supportLink);
+    expect(history.location.pathname)
+      .toEqual(`/${defaultAlertProps.enterpriseSlug}/admin/support`);
+  });
+
+  it('calls toggleClose when the close button is clicked', () => {
+    render(<BulkEnrollmentAlertModal {...defaultAlertProps} />);
+    const closeButton = screen.getByText('OK');
+    userEvent.click(closeButton);
+    expect(defaultAlertProps.toggleClose).toBeCalledTimes(1);
+  });
+});
+
+describe('BulkEnrollmentSubmit', () => {
+  const flushPromises = () => new Promise(setImmediate);
+  beforeEach(() => {
+    emailsDispatch.mockClear();
+    coursesDispatch.mockClear();
+    addToast.mockClear();
+    logError.mockClear();
+    defaultProps.returnToInitialStep.mockClear();
+  });
+
+  it('displays checkbox and button', () => {
+    render(<BulkEnrollmentSubmitWrapper {...defaultProps} />);
+    expect(screen.getByTestId(FINAL_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(NOTIFY_CHECKBOX_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('tests button does not work when no courses and emails selected', () => {
+    render(<BulkEnrollmentSubmitWrapper {...defaultProps} />);
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    expect(button).toBeDisabled();
+  });
+
+  it('tests button is not disabled when courses and emails are selected', () => {
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    expect(button).not.toBeDisabled();
+  });
+
+  it('tests button is disabled when courses are not selected but emails are', () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithEmailsSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    expect(button).toBeDisabled();
+  });
+
+  it('tests button is disabled when emails are not selected but courses are', () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithCoursesSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    expect(button).toBeDisabled();
+  });
+
+  it('tests passing correct data to api call', () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    userEvent.click(button);
+
+    const expectedParams = {
+      emails: userEmails,
+      course_run_keys: courseNames,
+      notify: true,
+    };
+
+    expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
+      defaultProps.enterpriseId,
+      expectedParams,
+    );
+    expect(logError).toBeCalledTimes(0);
+  });
+
+  it('tests notify toggle disables param to api service', () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    const checkbox = screen.getByTestId(NOTIFY_CHECKBOX_TEST_ID);
+    userEvent.click(checkbox);
+    userEvent.click(button);
+
+    const expectedParams = {
+      emails: userEmails,
+      course_run_keys: courseNames,
+      notify: false,
+    };
+    expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
+      defaultProps.enterpriseId,
+      expectedParams,
+    );
+    expect(logError).toBeCalledTimes(0);
+  });
+
+  it('test component clears selected emails and courses after successful submit', async () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    await userEvent.click(button);
+
+    expect(emailsDispatch).toBeCalledTimes(1);
+    expect(coursesDispatch).toBeCalledTimes(1);
+
+    expect(emailsDispatch).toHaveBeenCalledWith(
+      clearSelectionAction(),
+    );
+    expect(coursesDispatch).toHaveBeenCalledWith(
+      clearSelectionAction(),
+    );
+    expect(logError).toBeCalledTimes(0);
+  });
+
+  it('tests component creates toast after successful submit', async () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    await userEvent.click(button);
+
+    expect(addToast).toBeCalledTimes(1);
+    expect(logError).toBeCalledTimes(0);
+    expect(addToast).toHaveBeenCalledWith(
+      generateSuccessMessage(userEmails.length),
+    );
+  });
+
+  it('tests component logs error response on unsuccessful api call', async () => {
+    const mockPromiseReject = Promise.reject(new Error('something went wrong'));
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseReject);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    await userEvent.click(button);
+    await flushPromises();
+
+    expect(addToast).toBeCalledTimes(0);
+    expect(logError).toBeCalledTimes(1);
+  });
+
+  it('renders alert modal on unsuccessful api call', async () => {
+    const mockPromiseReject = Promise.reject(new Error('something went wrong'));
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseReject);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+
+    await userEvent.click(button);
+    await flushPromises();
+    expect(screen.getByText(ALERT_MODAL_TITLE_TEXT)).toBeInTheDocument();
+    expect(addToast).toBeCalledTimes(0);
+  });
+
+  it('alert modal closes when user clicks OK', async () => {
+    const mockPromiseReject = Promise.reject(new Error('something went wrong'));
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseReject);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    await userEvent.click(button);
+    await flushPromises();
+    const alertModalCloseButton = screen.getByText('OK');
+    userEvent.click(alertModalCloseButton);
+    expect(screen.queryByText(ALERT_MODAL_TITLE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('component calls return to initial step on successful api call', async () => {
+    const mockPromiseResolve = Promise.resolve({ data: {} });
+    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+
+    render(
+      <BulkEnrollmentSubmitWrapper
+        {...defaultProps}
+        bulkEnrollInfo={bulkEnrollWithAllSelectedRows}
+      />,
+    );
+    const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
+    await userEvent.click(button);
+    expect(defaultProps.returnToInitialStep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/BulkEnrollmentPage/stepper/constants.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/constants.jsx
@@ -7,7 +7,13 @@ export const FINAL_BUTTON_TEXT = 'Enroll learners';
 export const NEXT_BUTTON_TEST_ID = 'stepper-next';
 export const PREV_BUTTON_TEST_ID = 'stepper-prev';
 export const FINAL_BUTTON_TEST_ID = 'stepper-final';
+export const NOTIFY_CHECKBOX_TEST_ID = 'notify-checkbox';
+export const CUSTOMER_SUPPORT_HYPERLINK_TEST_ID = 'customer-support-hyperlink';
 export const ADD_LEARNERS_STEP = 'addLearners';
 export const REVIEW_STEP = 'review';
 export const ADD_COURSES_STEP = 'chooseCourses';
 export const ADD_COURSES_TITLE = 'Add courses';
+export const ALERT_MODAL_TITLE_TEXT = 'An error occurred behind the scenes';
+export const ALERT_MODAL_BODY_TEXT = 'We were not able to enroll your learners. Please wait a few'
+                                   / ' minutes and try again. If the problem persists, please ';
+export const SUPPORT_HYPERLINK_TEXT = 'contact enterprise customer support.';


### PR DESCRIPTION
[Jira ticket](https://openedx.atlassian.net/browse/ENT-4423)

Changes:
- new bulk enrollment submit component added to the stepper
   - the stepper now calls the license manager API on final submit  
   - success and error responses from the Licence Manager are handled according to ticket AC 
      - success cases take the user back to the first step and displays a success Toast
      - error cases open up a modal alert with a link to support
         - closing the modal should keep the user in the current final step
   

**Bulk Enrollment Submit component**   
- Desktop
![image](https://user-images.githubusercontent.com/67655836/117860437-4a690a80-b25e-11eb-8271-c03ab52b8cd5.png)

- Mobile
![image](https://user-images.githubusercontent.com/67655836/117861100-0e827500-b25f-11eb-94f0-33f5d6cfe086.png)


**Success Toast**
- Desktop
![image](https://user-images.githubusercontent.com/67655836/117860631-8308e400-b25e-11eb-87e4-278485a30205.png)

- Mobile
![image](https://user-images.githubusercontent.com/67655836/117860993-eabf2f00-b25e-11eb-8de6-afe60d7ff3cf.png)


**Error Alert Modal**
- Desktop
![image](https://user-images.githubusercontent.com/67655836/117860776-afbcfb80-b25e-11eb-9990-e3cb93863bf4.png)

- Mobile
![image](https://user-images.githubusercontent.com/67655836/117860848-c3686200-b25e-11eb-92c3-ee0f51176f53.png)


