### PR TITLE
fix: swap support form link to mailTo

### DIFF
--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
@@ -12,12 +12,15 @@ import {
   FINAL_BUTTON_TEST_ID,
   CUSTOMER_SUPPORT_HYPERLINK_TEST_ID,
   ALERT_MODAL_TITLE_TEXT,
+  SUPPORT_EMAIL_SUBJECT,
+  SUPPORT_EMAIL_BODY,
 } from './constants';
 import { BulkEnrollContext } from '../BulkEnrollmentContext';
 import { clearSelectionAction } from '../data/actions';
 import { ToastsContext } from '../../Toasts/ToastsProvider';
 import { renderWithRouter } from '../../test/testUtils';
 import LicenseManagerApiService from '../../../data/services/LicenseManagerAPIService';
+import { configuration } from '../../../config';
 
 jest.mock('../../../data/services/LicenseManagerAPIService', () => ({
   __esModule: true, // this property makes it work
@@ -26,15 +29,20 @@ jest.mock('../../../data/services/LicenseManagerAPIService', () => ({
   },
 }));
 
+const errorText = 'a 500 error occurred';
+const testSlug = 'test-enterprise';
+const testEntId = 'abc1234z-53c9-4071-b698-b8d436eb0295';
 const defaultProps = {
-  enterpriseId: 'abc1234z-53c9-4071-b698-b8d436eb0295',
-  enterpriseSlug: 'test-enterprise',
+  enterpriseId: testEntId,
+  enterpriseSlug: testSlug,
   returnToInitialStep: jest.fn(),
 };
 const defaultAlertProps = {
   isOpen: true,
   toggleClose: jest.fn(),
-  enterpriseSlug: 'test-enterprise',
+  enterpriseId: testEntId,
+  error: errorText,
+  enterpriseSlug: testSlug,
 };
 
 const emailsDispatch = jest.fn();
@@ -87,9 +95,8 @@ describe('BulkEnrollmentAlertModal', () => {
     expect(screen.getByText(ALERT_MODAL_TITLE_TEXT)).toBeInTheDocument();
   });
 
-  // TODO find out how to test hyperlinks that open in new windows
-  it.skip('links to support', async () => {
-    const { history } = renderWithRouter(
+  it('links to support', async () => {
+    renderWithRouter(
       <BulkEnrollmentAlertModal {...defaultAlertProps} />,
       {
         route: '/',
@@ -98,9 +105,9 @@ describe('BulkEnrollmentAlertModal', () => {
     );
     /* click link */
     const supportLink = screen.getByTestId(CUSTOMER_SUPPORT_HYPERLINK_TEST_ID);
-    await userEvent.click(supportLink);
-    expect(history.location.pathname)
-      .toEqual(`/${defaultAlertProps.enterpriseSlug}/admin/support`);
+    expect(decodeURIComponent(supportLink.href)).toEqual(
+      `mailto:${configuration.CUSTOMER_SUPPORT_EMAIL}?body=enterprise UUID: ${testEntId}\n${SUPPORT_EMAIL_BODY}${errorText}&subject=${SUPPORT_EMAIL_SUBJECT + testSlug}`,
+    );
   });
 
   it('calls toggleClose when the close button is clicked', () => {

--- a/src/components/BulkEnrollmentPage/stepper/constants.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/constants.jsx
@@ -14,6 +14,8 @@ export const REVIEW_STEP = 'review';
 export const ADD_COURSES_STEP = 'chooseCourses';
 export const ADD_COURSES_TITLE = 'Add courses';
 export const ALERT_MODAL_TITLE_TEXT = 'An error occurred behind the scenes';
-export const ALERT_MODAL_BODY_TEXT = 'We were not able to enroll your learners. Please wait a few'
-                                   / ' minutes and try again. If the problem persists, please ';
+export const ALERT_MODAL_BODY_TEXT = `We were not able to enroll your learners. Please wait a few
+                                       minutes and try again. If the problem persists, please `;
 export const SUPPORT_HYPERLINK_TEXT = 'contact enterprise customer support.';
+export const SUPPORT_EMAIL_SUBJECT = 'An error occurred during Subscription Enrollment for enterprise ';
+export const SUPPORT_EMAIL_BODY = 'The following error occurred when attempting to enroll learners: ';


### PR DESCRIPTION
### Background
Due to completion of ENT-4451, the support form no longer exists, thus we needed to update this.

We decided on a mailTo link for now (eventually support's help center will have a new form and we may want to link directly to that, but that is completely out of scope for anything Bulk Enrollment related)

*NOTE:* I am waiting on confirmation of the language used in the support email to ensure it is useful to the support team.

### What this changes
- Swaps HyperLink to MailtoLink component in BulkEnrollmentAlertModal.
- As part of this we now pass in the actual error message so that support gets context in the email automatically.
- Fixes an issue with the `ALERT_MODAL_BODY_TEXT` constant as the multiline format was not actually compatible with web browsers so it was displaying as just `NaN`

### Screenshot
![Screen Shot 2021-05-18 at 12 06 14 PM](https://user-images.githubusercontent.com/66267747/118695865-a80bd280-b7db-11eb-9916-a159a483d4f2.png)

