### PR TITLE
feat: allowing users to disable coupon code assignment emails

### DIFF
--- a/src/components/CodeAssignmentModal/BulkAssignFields.jsx
+++ b/src/components/CodeAssignmentModal/BulkAssignFields.jsx
@@ -7,7 +7,7 @@ import { normalizeFileUpload } from '../../utils';
 
 const BulkAssignFields = () => (
   <>
-    <h3 className="mb-2">Add Users</h3>
+    <h3 className="mb-2">Add learners</h3>
     <div className="pl-4 field-group">
       <Field
         name="email-addresses"

--- a/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
+++ b/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
@@ -11,7 +11,7 @@ import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';
 import remindEmailTemplate from './emailTemplate';
 import CodeAssignmentModal, { BaseCodeAssignmentModal } from '.';
-import { ASSIGNMENT_MODAL_FIELDS } from './constants';
+import { ASSIGNMENT_MODAL_FIELDS, NOTIFY_LEARNERS_CHECKBOX_TEST_ID } from './constants';
 import { displayCode, displaySelectedCodes } from '../CodeModal/codeModalHelpers';
 
 import {
@@ -170,5 +170,9 @@ describe('CodeAssignmentModal component', () => {
   it('renders a auto-reminder checkbox', () => {
     render(<CodeAssignmentModalWrapper />);
     expect(screen.getByText(ASSIGNMENT_MODAL_FIELDS['enable-nudge-emails'].label)).toBeInTheDocument();
+  });
+  it('renders notify learners toggle checkbox', () => {
+    render(<CodeAssignmentModalWrapper />);
+    expect(screen.getByTestId(NOTIFY_LEARNERS_CHECKBOX_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/src/components/CodeAssignmentModal/IndividualAssignFields.jsx
+++ b/src/components/CodeAssignmentModal/IndividualAssignFields.jsx
@@ -5,7 +5,7 @@ import RenderField from '../RenderField';
 
 const IndividualAssignFields = () => (
   <>
-    <h3>Add User</h3>
+    <h3>Add learner</h3>
     <Field
       name="email-address"
       type="email"

--- a/src/components/CodeAssignmentModal/constants.jsx
+++ b/src/components/CodeAssignmentModal/constants.jsx
@@ -22,3 +22,6 @@ export const ASSIGNMENT_MODAL_FIELDS = {
     label: 'Automate reminders',
   },
 };
+
+export const NOTIFY_LEARNERS_CHECKBOX_TEST_ID = 'notify-learners-checkbox';
+export const SUBMIT_BUTTON_TEST_ID = 'submit-button';


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-4476)

**Notify learners checked:**
**Desktop**
![image](https://user-images.githubusercontent.com/67655836/118840425-63447200-b895-11eb-899b-2b848f2e631b.png)

**Mobile**
![image](https://user-images.githubusercontent.com/67655836/118840512-77886f00-b895-11eb-929a-9712035d0444.png)

**Notify learners unchecked**
**Desktop**
![image](https://user-images.githubusercontent.com/67655836/118840710-a6064a00-b895-11eb-891e-77546fb6c407.png)

**Mobile**
![image](https://user-images.githubusercontent.com/67655836/118840590-8b33d580-b895-11eb-8dea-3abe578e3e8c.png)

This PR:
- Changes wording of modal from `Users` to `Learners`
- Adds a checkbox that toggles the visibility of the email template part of the component
- Checkbox also controls a new boolean `option` parameter fed into the API call to ecommerce on the modal submit
- Unit test to check that the checkbox is rendering

NOTE: discussed with the team and due to the current setup, the modal's submitHandler is untestable so it's currently impossible to test the checkbox's functionality of altering the options used within the handler function. There is currently a jira ticket that is going to deal with this issue and the need for this test will be added to it.
