### PR TITLE
fix: change rows to column view for mobile on Review step of stepper

### DIFF
--- a/src/components/BulkEnrollmentPage/BulkEnrollment.scss
+++ b/src/components/BulkEnrollmentPage/BulkEnrollment.scss
@@ -28,6 +28,16 @@
   }
 }
 
+@include media-breakpoint-down(md) {
+  .be-review-list {
+    display: flex;
+  }
+  .row {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 .sticky-stepper-footer {
   display: flex;
   flex-direction: column;

--- a/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
@@ -34,20 +34,20 @@ const ReviewStep = ({ setCurrentStep }) => {
       <h2 className="mb-5">{REVIEW_TITLE}</h2>
       <Row>
         <ReviewList
-          key="emails"
-          rows={selectedEmails}
-          accessor="userEmail"
-          dispatch={emailsDispatch}
-          subject={EMAILS}
-          returnToSelection={() => setCurrentStep(ADD_LEARNERS_STEP)}
-        />
-        <ReviewList
           key="courses"
           rows={selectedCourses}
           accessor="title"
           dispatch={coursesDispatch}
           subject={COURSES}
           returnToSelection={() => setCurrentStep(ADD_COURSES_STEP)}
+        />
+        <ReviewList
+          key="emails"
+          rows={selectedEmails}
+          accessor="userEmail"
+          dispatch={emailsDispatch}
+          subject={EMAILS}
+          returnToSelection={() => setCurrentStep(ADD_LEARNERS_STEP)}
         />
       </Row>
     </>


### PR DESCRIPTION
### Background
Using 2+ columns on mobile is not best for the mobile user experience.
This PR swaps to a single column and displays the boxes/cards on top of each other.

### Screenshots:
#### Before:
![Screen Shot 2021-05-19 at 4 43 18 PM](https://user-images.githubusercontent.com/66267747/118881689-58073b80-b8c1-11eb-8c79-d95b22f8a678.png)


#### After:
![Screen Shot 2021-05-19 at 4 34 57 PM](https://user-images.githubusercontent.com/66267747/118881223-d3b4b880-b8c0-11eb-832e-1b0f4b83fd2d.png)
![Screen Shot 2021-05-19 at 4 35 25 PM](https://user-images.githubusercontent.com/66267747/118881228-d6171280-b8c0-11eb-8f84-685c136594ef.png)
