### PR TITLE
ENT-4481: Admin Portal: Fix reporting config password field error

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -69,12 +69,13 @@ class ReportingConfigForm extends React.Component {
    */
   handleBlur = (e, validationFunction) => {
     // One special case for email fields
+    const field = e.target;
     this.setState((state) => ({
       invalidFields: {
         ...state.invalidFields,
-        [e.target.name]: validationFunction
+        [field.name]: validationFunction
           ? validationFunction()
-          : !e.target.value.length,
+          : !field.value.length,
       },
     }));
   };


### PR DESCRIPTION
**Jira Ticket:** [ENT-4481](https://openedx.atlassian.net/browse/ENT-4481)

__Description:__
Password field on Reporting Configurations screen on portal.edx.org is disabled by default. Enabling/selecting the field and updating the password causes an error. This error is coming for both the email and SFTP delivery report configurations. Please see the attached video to reproduce the issue.

**Acceptance Criteria:**
- Admins can successfully update the password.

**Testing Instructions:**
1. Go to the reporting configuration page of some enterprise customer at `/<enterprise-customer>/admin/reporting`
2. Add/update reporting configuration
3. Select the `Change Password ` checkbox
4. Try to update the password
5. Password should update without any error.