### PR TITLE
feat: making bulk enrollment stepper footer sticky

### DIFF
--- a/src/components/BulkEnrollmentPage/BulkEnrollment.scss
+++ b/src/components/BulkEnrollmentPage/BulkEnrollment.scss
@@ -1,4 +1,8 @@
 .bulk-enrollment {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
   .alert {
     margin-top: 2rem;
   }
@@ -38,8 +42,13 @@
   }
 }
 
-.sticky-stepper-footer {
+.sticky-footer-wrapper {
+  height: 70vh;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+
+  .stepper-step {
+    flex-grow: 1;
+    overflow: scroll;
+  }
 }

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
@@ -23,7 +23,7 @@ const mockStore = configureMockStore([thunk]);
 
 const testCourseName = 'TestCourseName';
 const testCourseRunKey = 'TestCourseRun';
-const testStartDate = '2020-09-10T04:00:00Z';
+const testStartDate = '2020-09-10T10:00:00Z';
 
 const searchResults = {
   nbHits: 1,

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
@@ -29,8 +29,8 @@ const BulkEnrollmentStepper = ({ subscription, enterpriseSlug, enterpriseId }) =
   return (
     <Stepper activeKey={currentStep}>
       <Stepper.Header className="my-3" />
-      <div className="sticky-stepper-footer">
-        <Container size="xl">
+      <div className="sticky-footer-wrapper">
+        <Container size="xl" className="stepper-step">
           <Stepper.Step eventKey={ADD_COURSES_STEP} title={ADD_COURSES_TITLE}>
             <AddCoursesStep
               enterpriseId={enterpriseId}

--- a/src/components/BulkEnrollmentPage/table/CourseSearchResultsCells.test.jsx
+++ b/src/components/BulkEnrollmentPage/table/CourseSearchResultsCells.test.jsx
@@ -5,7 +5,7 @@ import { configuration } from '../../../config';
 
 const testCourseName = 'TestCourseName';
 const testCourseRunKey = 'TestCourseRun';
-const testStartDate = '2020-09-10T04:00:00Z';
+const testStartDate = '2020-09-10T10:00:00Z';
 
 describe('CourseNameCell', () => {
   const row = {

--- a/src/components/EnterpriseApp/_EnterpriseApp.scss
+++ b/src/components/EnterpriseApp/_EnterpriseApp.scss
@@ -1,5 +1,6 @@
 .enterprise-app {
   position: relative;
+  display: flex;
 
   .content-wrapper {
     padding: 10px;
@@ -11,5 +12,8 @@
         padding-left: 51px;
       }
     }
+  }
+  .full-page {
+    flex: 1;
   }
 }

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -137,7 +137,7 @@ class EnterpriseApp extends React.Component {
                 isMobile={!matchesMediaQ}
               />
               <div
-                className="content-wrapper"
+                className="content-wrapper full-page"
                 tabIndex="-1"
                 ref={this.contentWrapperRef}
                 style={{

--- a/src/components/subscriptions/styles/_SubscriptionManagementPage.scss
+++ b/src/components/subscriptions/styles/_SubscriptionManagementPage.scss
@@ -1,4 +1,8 @@
 .manage-subscription {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
   .add-users-dropdown {
     .dropdown-menu {
       z-index: $zindex-fixed;


### PR DESCRIPTION
[jira](https://openedx.atlassian.net/browse/ENT-4548)

Notes for reviewers:
I've tried to include as many screenshots as possible but best way to fully test is fetching the branch and messing with the screen/window to ensure behaviors are as expected

**Screenshots:**

Desktop scrollable table filling screen, footer at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119560103-85e0fa00-bd71-11eb-876c-f20af31a7869.png)

Desktop table filling partial screen, footer at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119560203-9db87e00-bd71-11eb-899b-616ef513be58.png)

Desktop screen window resized smaller, footer at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119561868-b32ea780-bd73-11eb-8f38-53d7d6a14058.png)

Mobile step one scrollable table top of page, footer at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119561468-38658c80-bd73-11eb-93c7-1293b7c74c22.png)

Mobile step one scrollable table bottom of page, footer at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119561541-4fa47a00-bd73-11eb-9914-ead00faf6a41.png)

Mobile step two scrollable table top of page, foot at bottom of page
![image](https://user-images.githubusercontent.com/67655836/119561678-7cf12800-bd73-11eb-89c6-d7f00daf3aaa.png)

Note:
Tests altered to work for both PST and EST timezones