### PR TITLE
feat: Add partner column, show first partner only, for now

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -27,6 +27,7 @@ export const ENROLL_TEXT = 'Enroll learners';
 export const TABLE_HEADERS = {
   courseName: 'Course name',
   courseStartDate: 'Course start date',
+  partnerName: 'Partner',
   enroll: '',
 };
 
@@ -94,6 +95,10 @@ export const BaseCourseSearchResults = (props) => {
       Header: TABLE_HEADERS.courseStartDate,
       accessor: 'advertised_course_run.start',
       Cell: FormattedDateCell,
+    },
+    {
+      Header: TABLE_HEADERS.partnerName,
+      accessor: 'partners[0].name',
     },
   ], []);
 

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -92,13 +92,13 @@ export const BaseCourseSearchResults = (props) => {
       Cell: ({ value, row }) => <CourseNameCell value={value} row={row} enterpriseSlug={enterpriseSlug} />,
     },
     {
+      Header: TABLE_HEADERS.partnerName,
+      accessor: 'partners[0].name',
+    },
+    {
       Header: TABLE_HEADERS.courseStartDate,
       accessor: 'advertised_course_run.start',
       Cell: FormattedDateCell,
-    },
-    {
-      Header: TABLE_HEADERS.partnerName,
-      accessor: 'partners[0].name',
     },
   ], []);
 

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
@@ -111,16 +111,16 @@ describe('<CourseSearchResults />', () => {
     const tableHeaderCells = wrapper.find('TableHeaderCell');
     expect(tableHeaderCells.length).toBe(5);
     expect(tableHeaderCells.at(1).prop('Header')).toBe(TABLE_HEADERS.courseName);
-    expect(tableHeaderCells.at(2).prop('Header')).toBe(TABLE_HEADERS.courseStartDate);
-    expect(tableHeaderCells.at(3).prop('Header')).toBe(TABLE_HEADERS.partnerName);
+    expect(tableHeaderCells.at(2).prop('Header')).toBe(TABLE_HEADERS.partnerName);
+    expect(tableHeaderCells.at(3).prop('Header')).toBe(TABLE_HEADERS.courseStartDate);
     expect(tableHeaderCells.at(4).prop('Header')).toBe('');
 
     // Three table cells, one for sorting, one title, one course run
     const tableCells = wrapper.find('TableCell');
     expect(tableCells.length).toBe(5);
     expect(tableCells.at(1).text()).toBe(testCourseName);
-    expect(tableCells.at(2).text()).toBe('Sep 10, 2020');
-    expect(tableCells.at(3).text()).toBe('edX');
+    expect(tableCells.at(2).text()).toBe('edX');
+    expect(tableCells.at(3).text()).toBe('Sep 10, 2020');
     expect(tableCells.at(4).find(EnrollButton)).toHaveLength(1);
   });
   it('displays search pagination', () => {

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
@@ -39,6 +39,7 @@ const searchResults = {
         start: testStartDate,
       },
       key: 'foo',
+      partners: [{ name: 'edX' }, { name: 'another_unused' }],
     },
   ],
   page: 3,
@@ -108,17 +109,19 @@ describe('<CourseSearchResults />', () => {
 
     // Four header columns, one for sorting, one for Course Name, one for Course Run, one for the enroll column
     const tableHeaderCells = wrapper.find('TableHeaderCell');
-    expect(tableHeaderCells.length).toBe(4);
+    expect(tableHeaderCells.length).toBe(5);
     expect(tableHeaderCells.at(1).prop('Header')).toBe(TABLE_HEADERS.courseName);
     expect(tableHeaderCells.at(2).prop('Header')).toBe(TABLE_HEADERS.courseStartDate);
-    expect(tableHeaderCells.at(3).prop('Header')).toBe('');
+    expect(tableHeaderCells.at(3).prop('Header')).toBe(TABLE_HEADERS.partnerName);
+    expect(tableHeaderCells.at(4).prop('Header')).toBe('');
 
     // Three table cells, one for sorting, one title, one course run
     const tableCells = wrapper.find('TableCell');
-    expect(tableCells.length).toBe(4);
+    expect(tableCells.length).toBe(5);
     expect(tableCells.at(1).text()).toBe(testCourseName);
     expect(tableCells.at(2).text()).toBe('Sep 10, 2020');
-    expect(tableCells.at(3).find(EnrollButton)).toHaveLength(1);
+    expect(tableCells.at(3).text()).toBe('edX');
+    expect(tableCells.at(4).find(EnrollButton)).toHaveLength(1);
   });
   it('displays search pagination', () => {
     const wrapper = mount(<CourseSearchWrapper />);


### PR DESCRIPTION
Decision per UX sync meeting:

When more than one partner in algolia data, just display first one, for now


ENT-4608

looks like this with change:

<img width="1081" alt="Screen Shot 2021-06-02 at 2 19 41 PM" src="https://user-images.githubusercontent.com/528166/120532365-9ca8d180-c3ad-11eb-8611-2a81c4d14dd4.png">
