### PR TITLE
fix: Bulk Enrollment Selection Option Consistency

### DIFF
--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -13,7 +13,6 @@ import { SearchContext, SearchPagination } from '@edx/frontend-enterprise-catalo
 import StatusAlert from '../StatusAlert';
 import { CourseNameCell, FormattedDateCell } from './table/CourseSearchResultsCells';
 import { BulkEnrollContext } from './BulkEnrollmentContext';
-import { convertToSelectedRowsObject } from './helpers';
 import {
   setSelectedRowsAction,
 } from './data/actions';
@@ -85,6 +84,7 @@ export const BaseCourseSearchResults = (props) => {
 
   const { refinementsFromQueryParams } = useContext(SearchContext);
   const columns = useMemo(() => [
+    selectColumn,
     {
       Header: TABLE_HEADERS.courseName,
       accessor: 'title',
@@ -148,12 +148,10 @@ export const BaseCourseSearchResults = (props) => {
         columns={columns}
         data={searchResults?.hits || []}
         itemCount={searchResults?.nbHits}
-        manualSelectColumn={selectColumn}
         SelectionStatusComponent={AddCoursesSelectionStatus}
-        isSelectable
         pageCount={searchResults?.nbPages || 1}
         pageSize={searchResults?.hitsPerPage || 0}
-        initialState={{ selectedRowIds: convertToSelectedRowsObject(selectedCourses) }}
+        selectedFlatRows={selectedCourses}
         initialTableOptions={{
           getRowId: (row) => row.key,
         }}

--- a/src/components/BulkEnrollmentPage/helpers.js
+++ b/src/components/BulkEnrollmentPage/helpers.js
@@ -1,4 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-export const convertToSelectedRowsObject = (selectedRows) => selectedRows.reduce(
-  (acc, row) => { acc[row.id] = true; return acc; }, {},
-);

--- a/src/components/BulkEnrollmentPage/helpers.test.jsx
+++ b/src/components/BulkEnrollmentPage/helpers.test.jsx
@@ -1,9 +1,0 @@
-import { convertToSelectedRowsObject } from './helpers';
-
-describe('convertToSelectedRowsObject', () => {
-  it('creates an object has a property of the row id for each selected row with the value true', () => {
-    const rows = [{ id: 'foo' }, { id: 'bar' }];
-    const expected = { foo: true, bar: true };
-    expect(convertToSelectedRowsObject(rows)).toEqual(expected);
-  });
-});

--- a/src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx
@@ -11,7 +11,6 @@ import { logError } from '@edx/frontend-platform/logging';
 import { Link } from 'react-router-dom';
 import { BulkEnrollContext } from '../BulkEnrollmentContext';
 import { ADD_LEARNERS_TITLE } from './constants';
-import { convertToSelectedRowsObject } from '../helpers';
 import TableLoadingSkeleton from '../../TableComponent/TableLoadingSkeleton';
 import { BaseSelectWithContext, BaseSelectWithContextHeader } from '../table/BulkEnrollSelect';
 import BaseSelectionStatus from '../table/BaseSelectionStatus';
@@ -92,14 +91,6 @@ const AddLearnersStep = ({
     });
   }, [subscriptionUUID, enterpriseSlug]);
 
-  const selectedRowIds = useMemo(() => convertToSelectedRowsObject(selectedEmails), [selectedEmails]);
-
-  const initialState = useMemo(() => ({
-    pageSize: PAGE_SIZE,
-    pageIndex: 0,
-    selectedRowIds,
-  }), []);
-
   const initialTableOptions = useMemo(() => ({
     getRowId: (row, relativeIndex, parent) => row?.uuid || (parent ? [parent.id, relativeIndex].join('.') : relativeIndex),
   }), []);
@@ -122,7 +113,6 @@ const AddLearnersStep = ({
         manualPagination
         fetchData={fetchData}
         SelectionStatusComponent={AddLearnersSelectionStatus}
-        initialState={initialState}
         initialTableOptions={initialTableOptions}
         selectedFlatRows={selectedEmails}
       >

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.test.jsx
@@ -104,12 +104,13 @@ describe('BulkEnrollmentStepper', () => {
     expect(screen.queryByTestId(PREV_BUTTON_TEST_ID)).toBeInTheDocument();
     await act(() => mockEmailResponse);
   });
-  it('clicking previous from Add learners brings you back to Add courses', async () => {
+  it('clicking previous from Add learners brings you back to Add courses and retains selection', async () => {
     renderWithRouter(<StepperWrapper {...defaultProps} />);
     navigateToAddLearners();
     const prevButton = screen.getByTestId(PREV_BUTTON_TEST_ID);
     userEvent.click(prevButton);
     expect(screen.getAllByText(ADD_COURSES_TITLE)).toHaveLength(2);
+    expect(screen.getByText('All 2 selected')).toBeInTheDocument();
     await act(() => mockEmailResponse);
   });
   it('displays the user emails', async () => {


### PR DESCRIPTION
Selecting a course on the course selection step of the Bulk Enrollment stepper was not triggering the selection options/buttons/tool tip (what are we calling this?). It only triggered when clicking "Next" and then clicking Back to go back to the Course step. It also then would show "0 of N selected" which is not how the rest of the data tables behave.

We believe it is doing this because the underlying react-tables' selection is not refreshing the data until reload because of the way we are partially using selection props here and partially using our overrides.

This PR fixes the following:
- Fixes the selection behaviour by manually specifying selectedFlatRows in CourseSearchResults (this was already present in the AddLearner data table options).
- Removes unnecessary/duplicated props from the DataTables rendering in both CourseSearchResults and the AddLearners step components.
- Adds test to verify selection behaviour is present and functioning.