### PR TITLE
ENT-4507: feat: Front end work for showing Notification banner in Admin Portal

### DIFF
--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -22,6 +22,7 @@ import { features } from '../../config';
 import LmsConfigurations from '../../containers/LmsConfigurations';
 import { ROUTE_NAMES } from './constants';
 import EnterpriseAppSkeleton from './EnterpriseAppSkeleton';
+import FeatureAnnouncementBanner from '../FeatureAnnouncementBanner';
 
 class EnterpriseApp extends React.Component {
   constructor(props) {
@@ -144,6 +145,7 @@ class EnterpriseApp extends React.Component {
                   paddingLeft: matchesMediaQ ? sidebarWidth : defaultContentPadding,
                 }}
               >
+                <FeatureAnnouncementBanner enterpriseSlug={enterpriseSlug} />
                 <Switch>
                   <Redirect
                     exact

--- a/src/components/FeatureAnnouncementBanner/FeatureAnnouncementBanner.test.jsx
+++ b/src/components/FeatureAnnouncementBanner/FeatureAnnouncementBanner.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from '@testing-library/react';
+
+import FeatureAnnouncementBanner from './index';
+import LmsApiService from '../../data/services/LmsApiService';
+
+jest.mock('../../data/services/LmsApiService');
+
+const mockEnterpriseCustomer = {
+  enterprise_notification_banner: { text: 'This is a test notification.', id: 1 },
+};
+
+let container = null;
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+describe('<FeatureAnnouncementBanner />', () => {
+  it('renders correctly', async () => {
+    const flushPromises = () => new Promise(setImmediate);
+
+    LmsApiService.fetchEnterpriseBySlug.mockImplementation(() => Promise.resolve({
+      data: mockEnterpriseCustomer,
+    }));
+
+    await act(async () => {
+      render(<FeatureAnnouncementBanner enterpriseSlug="test-enterprise" />, container);
+      await flushPromises();
+    });
+
+    expect(container.textContent).toContain('This is a test notification.');
+  });
+
+  it('does not render if data is not available', async () => {
+    const flushPromises = () => new Promise(setImmediate);
+
+    LmsApiService.fetchEnterpriseBySlug.mockImplementation(() => Promise.resolve({
+      data: {},
+    }));
+
+    await act(async () => {
+      render(<FeatureAnnouncementBanner enterpriseSlug="test-enterprise" />, container);
+      await flushPromises();
+    });
+
+    expect(container.textContent).not.toContain('This is a test notification.');
+  });
+
+  it('calls markBannerNotificationAsRead on alert dismissal.', async () => {
+    const flushPromises = () => new Promise(setImmediate);
+
+    LmsApiService.fetchEnterpriseBySlug.mockImplementation(() => Promise.resolve({
+      data: mockEnterpriseCustomer,
+    }));
+    LmsApiService.markBannerNotificationAsRead.mockImplementation(() => Promise.resolve({}));
+
+    await act(async () => {
+      render(<FeatureAnnouncementBanner enterpriseSlug="test-enterprise" />, container);
+      await flushPromises();
+    });
+    expect(container.textContent).toContain('This is a test notification.');
+
+    const closeButton = document.getElementsByClassName('close')[0];
+    closeButton.click();
+    expect(LmsApiService.markBannerNotificationAsRead.mock.calls).toHaveLength(1);
+  });
+});

--- a/src/components/FeatureAnnouncementBanner/index.jsx
+++ b/src/components/FeatureAnnouncementBanner/index.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Alert } from '@edx/paragon';
+import { logError } from '@edx/frontend-platform/logging';
+
+import LmsApiService from '../../data/services/LmsApiService';
+
+const FeatureAnnouncementBanner = ({ enterpriseSlug }) => {
+  const [enterpriseNotificationBanner, setEnterpriseNotificationBanner] = useState({
+    text: null,
+    notificationId: null,
+  });
+  const [isRead, setIsRead] = useState(false);
+
+  const markAsRead = () => {
+    setIsRead(true);
+    LmsApiService.markBannerNotificationAsRead({
+      enterprise_slug: enterpriseSlug,
+      notification_id: enterpriseNotificationBanner.notificationId,
+    });
+  };
+
+  useEffect(() => {
+    LmsApiService.fetchEnterpriseBySlug(enterpriseSlug)
+      .then((response) => {
+        if (response.data && response.data.enterprise_notification_banner) {
+          setEnterpriseNotificationBanner({
+            text: response.data.enterprise_notification_banner.text,
+            notificationId: response.data.enterprise_notification_banner.id,
+          });
+        }
+      })
+      .catch((error) => {
+        // We can ignore errors here as user will se the banner in the next page refresh.
+        logError(error);
+      });
+  }, [enterpriseSlug]);
+
+  return (
+    isRead || !enterpriseNotificationBanner.text ? null : (
+      <div>
+        <Alert variant="info" dismissible onClose={markAsRead}>
+          <Alert.Heading>We have a new feature for you!</Alert.Heading>
+          <p>
+            {enterpriseNotificationBanner.text}
+          </p>
+        </Alert>
+      </div>
+    )
+  );
+};
+
+FeatureAnnouncementBanner.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+};
+
+export default FeatureAnnouncementBanner;

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -22,6 +22,8 @@ class LmsApiService {
 
   static enterpriseCustomerCatalogsUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise_catalogs/`
 
+  static notificationReadUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/read_notification`
+
   static fetchCourseOutline(courseId) {
     const options = {
       course_id: courseId,
@@ -202,6 +204,10 @@ class LmsApiService {
 
   static fetchEnterpriseCustomerCatalogs(enterpriseId) {
     return LmsApiService.apiClient().get(`${LmsApiService.enterpriseCustomerCatalogsUrl}?enterprise_customer=${enterpriseId}`);
+  }
+
+  static markBannerNotificationAsRead(formData) {
+    return LmsApiService.apiClient().post(LmsApiService.notificationReadUrl, formData);
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket:** [ENT-4507](https://openedx.atlassian.net/browse/ENT-4507)

__Description:__
As an enterprise admin, I want to see relevant product updates pop up in an informational message when I log into my Admin Portal in order that I may receive 'in-application notification' of new developments on edX.

__Acceptance Criteria:__
1. Front end: the ability to see that banner pop up when the admin logs in on the home page of the Admin Portal.

__Testing Instructions:__
1. Install the latest version of  edx-enterprise (note: backend was added in  `edx-enterprise==3.26.0` you need this version to test this PR)
2. Go to the django admin page for admin notification manager `/admin/enterprise/adminnotification/`
2. Add a new notification.
3. Now open admin portal and select any enterprise customer if not already selected. 
4. You should see a banner at the top with the message specified in step 2.
5. Click on the cross button at the top right corner of the banner.
6. Notification should go away, refresh the page and make sure banner does not re-appear.

