### PR TITLE
feat: Ordering change of sidebar menu items

### DIFF
--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -79,6 +79,12 @@ class Sidebar extends React.Component {
         hidden: !enableSubscriptionManagementScreen,
       },
       {
+        title: 'Subscription Enrollment',
+        to: `${baseUrl}/admin/${ROUTE_NAMES.bulkEnrollment}`,
+        icon: faBookOpen,
+        hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),
+      },
+      {
         title: 'Analytics',
         to: `${baseUrl}/admin/analytics`,
         icon: faChartBar,
@@ -89,12 +95,6 @@ class Sidebar extends React.Component {
         to: `${baseUrl}/admin/samlconfiguration`,
         icon: faIdCard,
         hidden: !features.SAML_CONFIGURATION || !enableSamlConfigurationScreen,
-      },
-      {
-        title: 'Subscription Enrollment',
-        to: `${baseUrl}/admin/${ROUTE_NAMES.bulkEnrollment}`,
-        icon: faBookOpen,
-        hidden: !(features.BULK_ENROLLMENT && enableSubscriptionManagementScreen),
       },
       {
         title: 'LMS Integration Configuration',


### PR DESCRIPTION
put subscription related items next to each other in sidebar

ENT-4678

<img width="318" alt="Screen Shot 2021-06-17 at 3 53 14 PM" src="https://user-images.githubusercontent.com/528166/122464159-86416f00-cf84-11eb-8b2d-5bb912a9ea28.png">
