### PR TITLE
fix: nudge reminder checkbox is not checked by default

### DIFF
--- a/src/components/CodeAssignmentModal/constants.jsx
+++ b/src/components/CodeAssignmentModal/constants.jsx
@@ -20,6 +20,7 @@ export const ASSIGNMENT_MODAL_FIELDS = {
     altText: 'More information',
     tooltipText: 'edX will remind learners to redeem their code 3, 10, and 19 days after you assign it.',
     label: 'Automate reminders',
+    defaultChecked: true,
   },
 };
 

--- a/src/components/ReduxFormCheckbox/__snapshots__/ReduxFormCheckbox.test.jsx.snap
+++ b/src/components/ReduxFormCheckbox/__snapshots__/ReduxFormCheckbox.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`<ReduxFormCheckbox /> renders checked correctly 1`] = `
     <input
       checked={true}
       className="form-check-input position-static"
+      defaultChecked={false}
       disabled={false}
       id="id"
       type="checkbox"
@@ -28,6 +29,7 @@ exports[`<ReduxFormCheckbox /> renders unchecked correctly 1`] = `
     <input
       checked={false}
       className="form-check-input position-static"
+      defaultChecked={false}
       disabled={false}
       id="id"
       type="checkbox"

--- a/src/components/ReduxFormCheckbox/index.jsx
+++ b/src/components/ReduxFormCheckbox/index.jsx
@@ -8,6 +8,7 @@ const ReduxFormCheckbox = (props) => {
     label,
     helptext,
     input,
+    defaultChecked,
   } = props;
 
   return (
@@ -19,6 +20,7 @@ const ReduxFormCheckbox = (props) => {
         {...input}
         id={id}
         type="checkbox"
+        defaultChecked={defaultChecked}
         checked={input.checked}
         label={label}
       />
@@ -28,6 +30,7 @@ const ReduxFormCheckbox = (props) => {
 
 ReduxFormCheckbox.defaultProps = {
   helptext: null,
+  defaultChecked: false,
 };
 
 ReduxFormCheckbox.propTypes = {
@@ -37,6 +40,7 @@ ReduxFormCheckbox.propTypes = {
     checked: PropTypes.bool,
   }).isRequired,
   helptext: PropTypes.string,
+  defaultChecked: PropTypes.bool,
 };
 
 export default ReduxFormCheckbox;


### PR DESCRIPTION
This PR fixes a frontend bug regarding checkbox not being checked by default even though the value being passed on backend is true. More details on the ticket: https://openedx.atlassian.net/browse/ENT-4569

