### PR TITLE
Move bulk action functionality to bulk action component

### DIFF
--- a/src/components/CouponDetails/CouponBulkActions.jsx
+++ b/src/components/CouponDetails/CouponBulkActions.jsx
@@ -1,56 +1,75 @@
-import React from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import {
   Button, Form,
 } from '@edx/paragon';
-import { BULK_ACTION } from './constants';
+import { BULK_ACTION, COUPON_FILTERS, COUPON_FILTER_TYPES } from './constants';
+import { getBASelectOptions, getFirstNonDisabledOption } from './helpers';
 
 const CouponBulkActions = ({
-  value, options, disabled, onChange, handleBulkAction,
-}) => (
-  <>
-    <Form.Group className="flex-grow-1" controlId={BULK_ACTION.controlId} name={BULK_ACTION.name}>
-      <Form.Control
-        className="float-right"
-        floatingLabel={BULK_ACTION.label}
-        as="select"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        disabled={disabled}
+  handleBulkAction, selectedToggle, numSelectedCodes, numUnassignedCodes, couponAvailable, isTableLoading, hasTableData,
+}) => {
+  const isAssignView = selectedToggle === COUPON_FILTERS.unassigned.value;
+  const isRedeemedView = selectedToggle === COUPON_FILTERS.redeemed.value;
+
+  const options = useMemo(() => getBASelectOptions({
+    isAssignView,
+    isRedeemedView,
+    hasTableData,
+    couponAvailable,
+    numUnassignedCodes,
+    numSelectedCodes,
+  }), [numUnassignedCodes, numSelectedCodes, selectedToggle, hasTableData, couponAvailable]);
+
+  const [value, setValue] = useState(getFirstNonDisabledOption(options));
+  useEffect(() => {
+    setValue(getFirstNonDisabledOption(options));
+  }, [numUnassignedCodes, numSelectedCodes, selectedToggle, hasTableData, couponAvailable]);
+  const noActionsAvailable = options.every(option => option.disabled);
+
+  return (
+    <>
+      <Form.Group className="flex-grow-1" controlId={BULK_ACTION.controlId} name={BULK_ACTION.name}>
+        <Form.Control
+          className="float-right"
+          floatingLabel={BULK_ACTION.label}
+          as="select"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          disabled={isTableLoading || noActionsAvailable}
+        >
+          {options.map(
+            ({ label, value: optionValue, disabled: optionDisabled }) => (
+              <option
+                key={optionValue}
+                value={optionValue}
+                disabled={optionDisabled}
+              >
+                {label}
+              </option>
+            ),
+          )}
+        </Form.Control>
+      </Form.Group>
+      <Button
+        className="ml-2 mb-3"
+        onClick={() => handleBulkAction(value)}
+        disabled={isTableLoading || noActionsAvailable}
       >
-        {options.map(
-          ({ label, value: optionValue, disabled: optionDisabled }) => (
-            <option
-              key={optionValue}
-              value={optionValue}
-              disabled={optionDisabled}
-            >
-              {label}
-            </option>
-          ),
-        )}
-      </Form.Control>
-    </Form.Group>
-    <Button
-      className="ml-2 mb-3"
-      onClick={handleBulkAction}
-      disabled={disabled}
-    >
-      Go
-    </Button>
-  </>
-);
+        Go
+      </Button>
+    </>
+  );
+};
 
 CouponBulkActions.propTypes = {
-  value: PropTypes.string.isRequired,
-  options: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
-    disabled: PropTypes.bool.isRequired,
-  })).isRequired,
-  onChange: PropTypes.func.isRequired,
-  disabled: PropTypes.bool.isRequired,
+  selectedToggle: PropTypes.oneOf(Object.values(COUPON_FILTER_TYPES)).isRequired,
+  numSelectedCodes: PropTypes.number.isRequired,
+  numUnassignedCodes: PropTypes.number.isRequired,
+  couponAvailable: PropTypes.bool.isRequired,
+  isTableLoading: PropTypes.bool.isRequired,
+  hasTableData: PropTypes.bool.isRequired,
   handleBulkAction: PropTypes.func.isRequired,
 };
 

--- a/src/components/CouponDetails/CouponBulkActions.jsx
+++ b/src/components/CouponDetails/CouponBulkActions.jsx
@@ -25,7 +25,7 @@ const CouponBulkActions = ({
   const [value, setValue] = useState(getFirstNonDisabledOption(options));
   useEffect(() => {
     setValue(getFirstNonDisabledOption(options));
-  }, [numUnassignedCodes, numSelectedCodes, selectedToggle, hasTableData, couponAvailable]);
+  }, [options]);
   const noActionsAvailable = options.every(option => option.disabled);
 
   return (

--- a/src/components/CouponDetails/CouponBulkActions.test.jsx
+++ b/src/components/CouponDetails/CouponBulkActions.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { ACTIONS, BULK_ACTION, COUPON_FILTER_TYPES } from './constants';
+import CouponBulkActions from './CouponBulkActions';
+
+const props = {
+  handleBulkAction: jest.fn(),
+  selectedToggle: COUPON_FILTER_TYPES.unassigned,
+  hasTableData: true,
+  couponAvailable: true,
+  isTableLoading: false,
+  numSelectedCodes: 0,
+  numUnassignedCodes: 3,
+};
+
+describe('CouponBulkActions', () => {
+  beforeEach(() => {
+    props.handleBulkAction.mockClear();
+  });
+  it('has disabled select and button when table is loading', () => {
+    const modifiedProps = {
+      ...props,
+      isTableLoading: true,
+    };
+    render(<CouponBulkActions {...modifiedProps} />);
+    expect(screen.getByLabelText(BULK_ACTION.label)).toHaveProperty('disabled', true);
+    expect(screen.getByText('Go')).toHaveProperty('disabled', true);
+  });
+  it('has disabled select and button when no actions are available', () => {
+    const modifiedProps = {
+      ...props,
+      couponAvailable: false,
+    };
+    render(<CouponBulkActions {...modifiedProps} />);
+    expect(screen.getByLabelText(BULK_ACTION.label)).toHaveProperty('disabled', true);
+    expect(screen.getByText('Go')).toHaveProperty('disabled', true);
+  });
+  it('does not disable select and buttons when options are available', () => {
+    render(<CouponBulkActions {...props} />);
+    expect(screen.getByLabelText(BULK_ACTION.label)).toHaveProperty('disabled', false);
+    expect(screen.getByText('Go')).toHaveProperty('disabled', false);
+  });
+  it('sets the value to the first non-disabled option by default - unassigned', () => {
+    // getting the first non-disable option and getting the options is tested separately in helpers.test.js
+    render(<CouponBulkActions {...props} />);
+    screen.getByText(ACTIONS.assign.label);
+    expect(screen.getByLabelText(BULK_ACTION.label)).toHaveProperty('value', ACTIONS.assign.value);
+  });
+  it('sets the value to the first non-disabled option by default - unredeeemed', () => {
+    // getting the first non-disable option and getting the options is tested separately in helpers.test.js
+    render(<CouponBulkActions {...props} selectedToggle={COUPON_FILTER_TYPES.unredeemed} />);
+    screen.getByText(ACTIONS.remind.label);
+    expect(screen.getByLabelText(BULK_ACTION.label)).toHaveProperty('value', ACTIONS.remind.value);
+  });
+  it('changes the value when a new value is selected', async () => {
+    render(<CouponBulkActions {...props} selectedToggle={COUPON_FILTER_TYPES.unredeemed} numSelectedCodes={1} />);
+    expect(screen.getByText(ACTIONS.remind.label)).toHaveProperty('disabled', false);
+    expect(screen.getByText(ACTIONS.revoke.label)).toHaveProperty('disabled', false);
+    userEvent.selectOptions(screen.getByLabelText(BULK_ACTION.label), [ACTIONS.revoke.label]);
+    expect(await screen.findByLabelText(BULK_ACTION.label)).toHaveProperty('value', ACTIONS.revoke.value);
+  });
+  it('calls handle bulk action with the selected value - default', () => {
+    render(<CouponBulkActions {...props} />);
+    userEvent.click(screen.getByText('Go'));
+    expect(props.handleBulkAction).toHaveBeenCalledWith(ACTIONS.assign.value);
+  });
+  it('calls handle bulk action with the selected value - after change', async () => {
+    render(<CouponBulkActions {...props} selectedToggle={COUPON_FILTER_TYPES.unredeemed} numSelectedCodes={1} />);
+    expect(screen.getByText(ACTIONS.remind.label)).toHaveProperty('disabled', false);
+    expect(screen.getByText(ACTIONS.revoke.label)).toHaveProperty('disabled', false);
+    userEvent.selectOptions(screen.getByLabelText(BULK_ACTION.label), [ACTIONS.revoke.label]);
+    userEvent.click(screen.getByText('Go'));
+    expect(props.handleBulkAction).toHaveBeenCalledWith(ACTIONS.revoke.value);
+  });
+});

--- a/src/components/CouponDetails/FilterBulkActionRow.jsx
+++ b/src/components/CouponDetails/FilterBulkActionRow.jsx
@@ -30,7 +30,6 @@ FilterBulkActionRow.propTypes = {
   couponBulkActionProps: PropTypes.shape().isRequired,
   isTableLoading: PropTypes.bool.isRequired,
   selectedToggle: PropTypes.oneOf(Object.values(COUPON_FILTER_TYPES)).isRequired,
-
 };
 
 export default FilterBulkActionRow;

--- a/src/components/CouponDetails/FilterBulkActionRow.jsx
+++ b/src/components/CouponDetails/FilterBulkActionRow.jsx
@@ -3,19 +3,22 @@ import PropTypes from 'prop-types';
 
 import CouponFilters from './CouponFilters';
 import CouponBulkActions from './CouponBulkActions';
+import { COUPON_FILTER_TYPES } from './constants';
 
 // Display component to handle layout
 
-const FilterBulkActionRow = ({ couponFilterProps, couponBulkActionProps }) => (
+const FilterBulkActionRow = ({ couponFilterProps, couponBulkActionProps, ...sharedProps }) => (
   <div className="d-flex justify-content-between mt-3">
     <div className="toggles">
       <CouponFilters
         {...couponFilterProps}
+        {...sharedProps}
       />
     </div>
     <div className="bulk-actions m-md-0 d-flex justify-content-end">
       <CouponBulkActions
         {...couponBulkActionProps}
+        {...sharedProps}
       />
     </div>
   </div>
@@ -25,6 +28,9 @@ FilterBulkActionRow.propTypes = {
   // specific PropTypes are defined on the CouponFilters and CouponBulkActions components, respectively
   couponFilterProps: PropTypes.shape().isRequired,
   couponBulkActionProps: PropTypes.shape().isRequired,
+  isTableLoading: PropTypes.bool.isRequired,
+  selectedToggle: PropTypes.oneOf(Object.values(COUPON_FILTER_TYPES)).isRequired,
+
 };
 
 export default FilterBulkActionRow;

--- a/src/components/CouponDetails/helpers.test.jsx
+++ b/src/components/CouponDetails/helpers.test.jsx
@@ -36,6 +36,7 @@ describe('getFirstNonDisabledOption', () => {
     [[{ value: 'foo', disabled: true }, { value: 'bar' }], 'bar'],
     [[{ value: 'foo' }, { value: 'bar', disabled: false }, { value: 'baz', disabled: true }], 'foo'],
     [[{ value: 'foo', disabled: true }, { value: 'bar', disabled: true }, { value: 'baz', disabled: false }], 'baz'],
+    [[{ value: 'foo', disabled: false }, { value: 'bar', disabled: true }, { value: 'baz', disabled: true }], 'foo'],
   ])('it returns the first non-disabled option %#', (options, expected) => {
     expect(getFirstNonDisabledOption(options)).toEqual(expected);
   });


### PR DESCRIPTION
Component is responsible for it's value and options instead of the parent
Allows for easier testing and debugging

There are no visual changes. This fixes a bug I introduced where when you were clicking back to "Remind" from "Redeemed", the value of the BulkAction select did not update as it ought to. 