### PR TITLE
feat: banner reminding admins to allocate licenses

### DIFF
--- a/src/components/subscriptions/licenses/LicenseAllocationBanner.jsx
+++ b/src/components/subscriptions/licenses/LicenseAllocationBanner.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+import { Alert } from '@edx/paragon';
+
+export const ALLOCATION_BANNER_TEXT = 'In accordance with edX privacy policies, learners that do not activate their allocated'
++ ' licenses within 90 days of invitation are purged from the record tables below.';
+/**
+ * Displays simple dismissible banner to remind admins.
+ */
+const LicenseAllocationBanner = () => {
+  const [closed, setClosed] = useState(false);
+
+  if (closed) { return null; }
+
+  return (
+    <Alert
+      className="license-allocation-alert"
+      onClose={() => setClosed(true)}
+      variant="info"
+      dismissible
+    >
+      {ALLOCATION_BANNER_TEXT}
+    </Alert>
+  );
+};
+
+export default LicenseAllocationBanner;

--- a/src/components/subscriptions/licenses/LicenseAllocationHeader.jsx
+++ b/src/components/subscriptions/licenses/LicenseAllocationHeader.jsx
@@ -3,6 +3,7 @@ import { Row, Col } from '@edx/paragon';
 import SearchBar from '../../SearchBar';
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import DownloadCsvButton from '../buttons/DownloadCsvButton';
+import LicenseAllocationBanner from './LicenseAllocationBanner';
 
 const LicenseAllocationHeader = () => {
   const {
@@ -17,6 +18,7 @@ const LicenseAllocationHeader = () => {
         {' of '}
         {subscription.licenses?.total} licenses allocated
       </p>
+      <LicenseAllocationBanner />
       <Row className="justify-content-between">
         <Col lg={6} xs={12} className="mb-2">
           <SearchBar

--- a/src/components/subscriptions/tests/licenses/LicenseAllocationBanner.test.jsx
+++ b/src/components/subscriptions/tests/licenses/LicenseAllocationBanner.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import LicenseAllocationBanner, { ALLOCATION_BANNER_TEXT } from '../../licenses/LicenseAllocationBanner';
+
+describe('<LicenseAllocationBanner />', () => {
+  test('render component', () => {
+    render(<LicenseAllocationBanner />);
+    expect(screen.queryByText(ALLOCATION_BANNER_TEXT)).toBeTruthy();
+  });
+
+  test('component closes', () => {
+    render(<LicenseAllocationBanner />);
+    expect(screen.queryByText(ALLOCATION_BANNER_TEXT)).toBeTruthy();
+    fireEvent(
+      screen.getByText('Close alert'),
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+    expect(screen.queryByText(ALLOCATION_BANNER_TEXT)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Closes [ENT-4457](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=628&modal=detail&selectedIssue=ENT-4457)

Adds dismissible alert.

![Screen Shot 2021-07-07 at 3 40 50 PM](https://user-images.githubusercontent.com/6687387/124819929-d9cb2b00-df3a-11eb-8e1e-f3a694ad686b.png)
