### PR TITLE
style: Bulk Enrollment: Review Step: Add title & aria label variables

### DIFF
--- a/src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx
@@ -7,7 +7,9 @@ import PropTypes from 'prop-types';
 
 import { deleteSelectedRowAction } from '../data/actions';
 
-const ReviewItem = ({ row, accessor, dispatch }) => {
+const ReviewItem = ({
+  row, accessor, dispatch, altText,
+}) => {
   const onClick = () => {
     dispatch(deleteSelectedRowAction(row.id));
   };
@@ -23,8 +25,9 @@ const ReviewItem = ({ row, accessor, dispatch }) => {
               iconAs={Icon}
               style={{ cursor: 'pointer' }}
               data-testid="delete-button"
-              alt="Remove selection"
+              alt={altText}
               onClick={onClick}
+              title={altText}
             />
           </Card.Text>
         </Card.Body>
@@ -43,6 +46,8 @@ ReviewItem.propTypes = {
   accessor: PropTypes.string.isRequired,
   /* For dispatching actions on the rows. Will dispatch the deleteSelectedRowAction */
   dispatch: PropTypes.func.isRequired,
+  /* Is used as label text on hover as well as Aria label for screenreaders for the remove button. */
+  altText: PropTypes.string.isRequired,
 };
 
 export default ReviewItem;

--- a/src/components/BulkEnrollmentPage/stepper/ReviewItem.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewItem.test.jsx
@@ -2,7 +2,9 @@ import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { mount } from 'enzyme';
 
+import { IconButton } from '@edx/paragon';
 import ReviewItem from './ReviewItem';
 import { deleteSelectedRowAction } from '../data/actions';
 
@@ -15,6 +17,7 @@ const defaultProps = {
   },
   accessor: 'foo',
   dispatch: jest.fn(),
+  altText: 'deleteButton alt text',
 };
 
 describe('AddLearnersStep', () => {
@@ -24,6 +27,11 @@ describe('AddLearnersStep', () => {
   it('displays an item via the accessor', () => {
     render(<ReviewItem {...defaultProps} />);
     expect(screen.getByText(defaultProps.row.values.foo)).toBeInTheDocument();
+  });
+  it('remove button gets rendered with a correctly named aria label prop', () => {
+    const wrapper = mount(<ReviewItem {...defaultProps} />);
+    const instance = wrapper.find(IconButton);
+    expect(instance.prop('alt')).toEqual(defaultProps.altText);
   });
   it('dispatches the deleteSelected row action when the delete button is clicked', () => {
     render(<ReviewItem {...defaultProps} />);

--- a/src/components/BulkEnrollmentPage/stepper/ReviewList.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewList.jsx
@@ -62,7 +62,9 @@ const ReviewList = ({
             </Button>
           </Alert>
         )}
-        {displayRows.map((row) => <ReviewItem key={row.id} row={row} accessor={accessor} dispatch={dispatch} />)}
+        {displayRows.map((row) => (
+          <ReviewItem key={row.id} row={row} accessor={accessor} dispatch={dispatch} altText={subject.removal} />
+        ))}
       </ul>
       <ShowHideButton
         data-testid="show-hide"
@@ -88,6 +90,7 @@ ReviewList.propTypes = {
     singular: PropTypes.string.isRequired,
     plural: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
+    removal: PropTypes.string.isRequired,
   }).isRequired,
   /* Function to return the user to the table where these rows were selected */
   returnToSelection: PropTypes.func.isRequired,

--- a/src/components/BulkEnrollmentPage/stepper/ReviewList.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewList.test.jsx
@@ -27,6 +27,7 @@ const defaultProps = {
     singular: 'wug',
     plural: 'wugs',
     title: 'Wugs',
+    removal: 'Remove Wugs. Return to egg.',
   },
   returnToSelection: jest.fn(),
 };
@@ -52,6 +53,10 @@ describe('ReviewList', () => {
   it('displays a title', () => {
     render(<ReviewList {...defaultProps} />);
     expect(screen.getByText(defaultProps.subject.title)).toBeInTheDocument();
+  });
+  it('renders delete button hover title', () => {
+    render(<ReviewList {...defaultProps} />);
+    expect(screen.getAllByTitle(defaultProps.subject.removal)[0]).toBeInTheDocument();
   });
   it('displays the number of rows selected', () => {
     render(<ReviewList {...defaultProps} />);

--- a/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
@@ -10,12 +10,14 @@ const LEARNERS = {
   singular: 'learner',
   plural: 'learners',
   title: 'Learners',
+  removal: 'Remove learner',
 };
 
 const COURSES = {
   singular: 'course',
   plural: 'courses',
   title: 'Courses',
+  removal: 'Remove course',
 };
 
 const ReviewStep = ({ setCurrentStep }) => {


### PR DESCRIPTION
#### Background
We want to add hover text for the delete icon on the Review Step of the Bulk Enrollment Stepper.
I also wanted to make the Aria label text more descriptive to benefit screenreaders better, so I added prop/parameters to differentiate course and learner ReviewItems at least in the context of Aria & title texts.

#### Specific Changes
- removal, altText props
  - Update existing `alt=` field on IconButton to use the altText prop.
  - Add `title=` attribute to IconButton (it accepts attr passthroughs)
- Add a test for the title (while aria labels show in the dom tree, they aren't actually visible so react testing library's docs state they aren't accessible to screen, but I at least wanted to verify one of these was showing properly and thus the prop passing was working as intended)

**Note:** There are no before/after screenshots, because I cannot pause the hover text on the delete button to showcase this. 😞  But here's a screenshot at least explaining which buttons we're affecting here:
![Screen Shot 2021-07-07 at 4 18 34 PM](https://user-images.githubusercontent.com/66267747/124823510-4d6f3700-df3f-11eb-9800-8759c5bcd52a.png)

