### PR TITLE
Adds event tracking for licensee expiration actions in modal and alert

### DIFF
--- a/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Cookies from 'universal-cookie';
 import { useToggle } from '@edx/paragon';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import SubscriptionExpiredModal from './SubscriptionExpiredModal';
 import SubscriptionExpiringModal from './SubscriptionExpiringModal';
@@ -90,17 +91,38 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
     }
   }, [isSubscriptionExpired]);
 
+  const emitAlertActionEvent = () => {
+    sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.modal.support_cta.clicked', {
+      expiration_threshold: subscriptionExpirationThreshold,
+      days_until_expiration: daysUntilExpiration,
+    });
+  };
+
+  const emitAlertDismissedEvent = () => {
+    sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.modal.dismissed', {
+      expiration_threshold: subscriptionExpirationThreshold,
+      days_until_expiration: daysUntilExpiration,
+    });
+  };
+
+  const handleCloseModal = (closeModal) => {
+    emitAlertDismissedEvent();
+    closeModal();
+  };
+
   return (
     <>
       <SubscriptionExpiringModal
         isOpen={isExpiringModalOpen}
-        onClose={closeExpiringModal}
+        onClose={() => handleCloseModal(closeExpiringModal)}
+        onAction={() => emitAlertActionEvent(false)}
         expirationThreshold={subscriptionExpirationThreshold}
         enterpriseId={enterpriseId}
       />
       <SubscriptionExpiredModal
         isOpen={isExpiredModalOpen}
-        onClose={closeExpiredModal}
+        onClose={() => handleCloseModal(closeExpiredModal)}
+        onAction={() => emitAlertActionEvent(false)}
       />
     </>
   );

--- a/src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx
@@ -13,6 +13,7 @@ export const EXPIRED_MODAL_TITLE = 'This subscription cohort is expired';
 const SubscriptionExpiredModal = ({
   onClose,
   isOpen,
+  onAction,
 }) => {
   const { subscription: { expirationDate } } = useContext(SubscriptionDetailContext);
 
@@ -36,7 +37,7 @@ const SubscriptionExpiredModal = ({
           <ModalDialog.CloseButton variant="tertiary">
             Dismiss
           </ModalDialog.CloseButton>
-          <ContactCustomerSupportButton />
+          <ContactCustomerSupportButton onClick={onAction} />
         </ActionRow>
       </ModalDialog.Footer>
     </ModalDialog>
@@ -45,6 +46,7 @@ const SubscriptionExpiredModal = ({
 
 SubscriptionExpiredModal.propTypes = {
   onClose: PropTypes.func.isRequired,
+  onAction: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
 };
 

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -15,6 +15,7 @@ const SubscriptionExpiringModal = ({
   isOpen,
   expirationThreshold,
   enterpriseId,
+  onAction,
 }) => {
   const { subscription: { daysUntilExpiration, expirationDate } } = useContext(SubscriptionDetailContext);
 
@@ -66,7 +67,7 @@ const SubscriptionExpiringModal = ({
           <ModalDialog.CloseButton variant="tertiary">
             Dismiss
           </ModalDialog.CloseButton>
-          <ContactCustomerSupportButton />
+          <ContactCustomerSupportButton onClick={onAction} />
         </ActionRow>
       </ModalDialog.Footer>
     </ModalDialog>
@@ -76,6 +77,7 @@ const SubscriptionExpiringModal = ({
 SubscriptionExpiringModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   enterpriseId: PropTypes.string.isRequired,
+  onAction: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
   expirationThreshold: PropTypes.number,
 };

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
@@ -15,6 +15,10 @@ import {
   SubscriptionManagementContext,
 } from '../TestUtilities';
 
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendTrackEvent: jest.fn(),
+}));
+
 // PropType validation for state is done by SubscriptionManagementContext
 // eslint-disable-next-line react/prop-types
 const ExpirationBannerWithContext = ({ detailState }) => (

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
@@ -18,6 +18,10 @@ import {
   SubscriptionManagementContext,
 } from '../TestUtilities';
 
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendTrackEvent: jest.fn(),
+}));
+
 // PropType validation for state is done by SubscriptionManagementContext
 // eslint-disable-next-line react/prop-types
 const ExpirationModalsWithContext = ({ detailState }) => (


### PR DESCRIPTION
## Closes [ENT-4633](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=628&modal=detail&selectedIssue=ENT-4633)

#### Context
When a subscription plan nears its expiration date, admin users are presented warnings in the form of modals and alerts, (some of) which have actions to dismiss them or contact customer support. Example:

<img src="https://user-images.githubusercontent.com/6687387/127414100-e62f105e-9620-4274-b3c4-0bab030fb72a.png" width="370" height="300">


#### Events
Event names:

- `edx.admin_portal.subscriptions.expiration.modal.dismissed`
- `edx.admin_portal.subscriptions.expiration.modal.support_cta.clicked`
- `edx.admin_portal.subscriptions.expiration.alert.dismissed`
- `edx.admin_portal.subscriptions.expiration.alert.support_cta.clicked`

Event Properties:
- `expiration_threshold`: 30/60/120
- `days_until_expiration`: \<some_integer\>