### PR TITLE
feat(admin_portal): ENT-4531 Apply customer agreement 'disable_expiration_notification' setting to portal messages

### DIFF
--- a/src/components/BulkEnrollmentPage/index.test.jsx
+++ b/src/components/BulkEnrollmentPage/index.test.jsx
@@ -20,6 +20,7 @@ jest.mock('../../data/services/LicenseManagerAPIService', () => ({
   default: {
     fetchSubscriptions: jest.fn(),
     fetchSubscriptionUsersOverview: jest.fn(),
+    fetchCustomerAgreementData: jest.fn(),
   },
 }));
 
@@ -74,6 +75,45 @@ const subscriptions = Promise.resolve({
     count: 2,
   },
 });
+
+const mockCustomerAgreementDataMultiSubscriptions = Promise.resolve({
+  data: {
+
+    results: [{
+      uuid: '8ed1e80c-45fd-4b97-927a-5368b6aba6ea',
+      enterpriseId: 'foo',
+      enterpriseSlug: testSlug,
+      defaultEnterpriseCatalogUuid: 'blarghl',
+      subscriptions: [sub1, sub2],
+      disableExpirationNotifications: false,
+    }],
+    errors: null,
+    setErrors: jest.fn(),
+    forceRefresh: jest.fn(),
+    loading: false,
+    count: 1,
+  },
+});
+
+const mockCustomerAgreementDataSingleSubscription = Promise.resolve({
+  data: {
+
+    results: [{
+      uuid: '8ed1e80c-45fd-4b97-927a-5368b6aba6ea',
+      enterpriseId: 'foo',
+      enterpriseSlug: testSlug,
+      defaultEnterpriseCatalogUuid: 'blarghl',
+      subscriptions: [sub1],
+      disableExpirationNotifications: false,
+    }],
+    errors: null,
+    setErrors: jest.fn(),
+    forceRefresh: jest.fn(),
+    loading: false,
+    count: 1,
+  },
+});
+
 const singleSubscription = Promise.resolve({
   data: {
     results: [sub1],
@@ -105,6 +145,9 @@ const BulkEnrollmentWrapper = () => (
   </Provider>
 );
 
+LicenseManagerApiService.fetchCustomerAgreementData.mockImplementation(
+  () => mockCustomerAgreementDataMultiSubscriptions,
+);
 LicenseManagerApiService.fetchSubscriptions.mockImplementation(() => subscriptions);
 LicenseManagerApiService.fetchSubscriptionUsersOverview.mockImplementation(() => mockSubscriptionCount);
 
@@ -136,6 +179,9 @@ describe('<BulkEnrollmentPage />', () => {
   });
   describe('single subscription', () => {
     it('with one subscription, directly renders the course search page', async () => {
+      LicenseManagerApiService.fetchCustomerAgreementData.mockImplementation(
+        () => mockCustomerAgreementDataSingleSubscription,
+      );
       LicenseManagerApiService.fetchSubscriptions.mockImplementation(() => singleSubscription);
       LicenseManagerApiService.fetchSubscriptionUsersOverview.mockImplementation(() => mockSingleSubscriptionCount);
       renderWithRouter(<BulkEnrollmentWrapper />, { route: `/${testSlug}/admin/${ROUTE_NAMES.bulkEnrollment}` });

--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -11,17 +11,18 @@ import {
   SUBSCRIPTIONS,
 } from './constants';
 
+const subscriptionInitState = {
+  results: [],
+  count: 0,
+  next: null,
+  previous: null,
+};
 /*
  * This hook provides all customer agreement and subscription data
  * for the authenticated user and given enterprise customer UUID.
  */
 export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
-  const [subscriptions, setSubscriptions] = useState({
-    results: [],
-    count: 0,
-    next: null,
-    previous: null,
-  });
+  const [subscriptions, setSubscriptions] = useState({ ...subscriptionInitState });
 
   const forceRefresh = () => {
     setSubscriptions({ ...subscriptions });
@@ -34,12 +35,7 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
       .then((response) => {
         const { data: customerAgreementData } = camelCaseObject(response);
 
-        const subscriptionsData = {
-          results: [],
-          count: 0,
-          next: null,
-          previous: null,
-        };
+        const subscriptionsData = { ...subscriptionInitState };
         // Reshape the Customer Agreement API response into the flatter format for the app to use:
         if (customerAgreementData.results && customerAgreementData.count) {
           // Only look at customer agreements with subs:
@@ -50,7 +46,7 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
               // that subcription.
               const flattenedSubscriptionResults = customerAgreement.subscriptions.map(subscription => ({
                 ...subscription,
-                disableExpirationNotifications: (customerAgreement.disableExpirationNotifications || false),
+                showExpirationNotifications: !(customerAgreement.disableExpirationNotifications || false),
               }));
 
               subscriptionsData.results = subscriptionsData.results.concat(flattenedSubscriptionResults);
@@ -134,12 +130,7 @@ export const useSubscriptionUsers = ({
   errors,
   setErrors,
 }) => {
-  const [subscriptionUsers, setSubscriptionUsers] = useState({
-    results: [],
-    count: 0,
-    next: null,
-    previous: null,
-  });
+  const [subscriptionUsers, setSubscriptionUsers] = useState({ ...subscriptionInitState });
 
   useEffect(() => {
     if (!subscriptionUUID) {

--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -14,7 +14,7 @@ import ContactCustomerSupportButton from '../buttons/ContactCustomerSupportButto
 
 const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
   const {
-    subscription: { daysUntilExpiration, expirationDate },
+    subscription: { daysUntilExpiration, expirationDate, showExpirationNotifications },
   } = useContext(SubscriptionDetailContext);
   const [showBanner, setShowBanner] = useState(true);
 
@@ -108,7 +108,8 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
     emitAlertDismissedEvent();
   };
 
-  return (
+  return (showExpirationNotifications
+    && (
     <Alert
       className="expiration-alert mt-1"
       variant={alertType}
@@ -119,6 +120,7 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
     >
       {renderMessage(daysUntilExpiration)}
     </Alert>
+    )
   );
 };
 

--- a/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
@@ -27,7 +27,11 @@ import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider'
  * @returns Component containing modals related to subscription expiration.
  */
 const SubscriptionExpirationModals = ({ enterpriseId }) => {
-  const { subscription: { daysUntilExpiration } } = useContext(SubscriptionDetailContext);
+  const {
+    subscription: {
+      daysUntilExpiration, showExpirationNotifications,
+    },
+  } = useContext(SubscriptionDetailContext);
   const isSubscriptionExpired = daysUntilExpiration <= 0;
 
   /**
@@ -110,7 +114,8 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
     closeModal();
   };
 
-  return (
+  return (showExpirationNotifications
+    && (
     <>
       <SubscriptionExpiringModal
         isOpen={isExpiringModalOpen}
@@ -125,6 +130,7 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
         onAction={() => emitAlertActionEvent(false)}
       />
     </>
+    )
   );
 };
 

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
@@ -42,6 +42,7 @@ const defaultSubscriptions = {
           allocated: 10,
           total: 20,
         },
+        showExpirationNotifications: true,
       },
       {
         uuid: 'anotherid',
@@ -52,6 +53,7 @@ const defaultSubscriptions = {
           allocated: 11,
           total: 30,
         },
+        showExpirationNotifications: true,
       },
     ],
   },

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -31,6 +31,7 @@ export const SUBSCRIPTION_PLAN_ZERO_STATE = {
     unassigned: 10,
   },
   users: [],
+  showExpirationNotifications: true,
 };
 export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
   daysUntilExpiration: 240,
@@ -54,9 +55,10 @@ export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
       lastRemindDate: '2020-12-08',
     },
   ],
+  showExpirationNotifications: true,
 };
 const subscriptionPlan = (state) => {
-  const { daysUntilExpiration, licenses } = state;
+  const { daysUntilExpiration, licenses, showExpirationNotifications } = state;
   return ({
     title: TEST_SUBSCRIPTION_PLAN_TITLE,
     uuid: TEST_SUBSCRIPTION_PLAN_UUID,
@@ -71,6 +73,7 @@ const subscriptionPlan = (state) => {
       remaining: 1,
     },
     daysUntilExpiration,
+    showExpirationNotifications,
   });
 };
 
@@ -155,6 +158,7 @@ SubscriptionManagementContext.propTypes = {
       total: PropTypes.number.isRequired,
       allocated: PropTypes.number.isRequired,
     }).isRequired,
+    showExpirationNotifications: PropTypes.bool.isRequired,
     overview: PropTypes.shape({
       activated: PropTypes.number.isRequired,
       all: PropTypes.number.isRequired,

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
@@ -60,4 +60,14 @@ describe('<SubscriptionExpirationBanner />', () => {
     await waitForElementToBeRemoved(screen.queryByRole('alert'));
     expect(screen.queryByRole('alert')).toBeNull();
   });
+
+  test('does not render an alert when subscription expiration notifications are disabled', () => {
+    const detailStateCopy = {
+      ...SUBSCRIPTION_PLAN_ZERO_STATE,
+      daysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_MODERATE,
+      showExpirationNotifications: false,
+    };
+    render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
 });

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
@@ -50,6 +50,17 @@ describe('<SubscriptionExpirationModals />', () => {
       expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeFalsy();
     });
 
+    test('do not render expired modal when expiration notifications are disabled', () => {
+      const detailStateCopy = {
+        ...SUBSCRIPTION_PLAN_ZERO_STATE,
+        daysUntilExpiration: 0,
+        showExpirationNotifications: false,
+      };
+      render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
+      expect(screen.queryByLabelText(EXPIRED_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeFalsy();
+    });
+
     test('expired modal is dismissible', () => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
@@ -75,6 +86,17 @@ describe('<SubscriptionExpirationModals />', () => {
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
       expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeTruthy();
       expect(screen.queryByText(`${threshold} days`, { exact: false })).toBeTruthy();
+    });
+
+    test('do not render expiring modal when expiration notifications are disabled', () => {
+      const detailStateCopy = {
+        ...SUBSCRIPTION_PLAN_ZERO_STATE,
+        daysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+        showExpirationNotifications: false,
+      };
+      render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
+      expect(screen.queryByLabelText(EXPIRED_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeFalsy();
     });
 
     test.each([

--- a/src/data/services/LicenseManagerAPIService.js
+++ b/src/data/services/LicenseManagerAPIService.js
@@ -147,6 +147,14 @@ class LicenseManagerApiService {
     const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/bulk-license-enrollment/?enterprise_customer_uuid=${enterpriseUuid}`;
     return LicenseManagerApiService.apiClient().post(url, options);
   }
+
+  static fetchCustomerAgreementData(options) {
+    const queryParams = {
+      ...options,
+    };
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/customer-agreement/?${qs.stringify(queryParams)}`;
+    return LicenseManagerApiService.apiClient().get(url);
+  }
 }
 
 export default LicenseManagerApiService;


### PR DESCRIPTION
ENT-4531. This PR: 

Commits can be reviewed separately:
feat(admin_portal): 🚧 Swap use of subscription API for customer-agreement API since it's a superset of the subscription data. 
feat(admin_portal): ✨ Apply customer agreement 'disable_expiration_notification' setting to portal messages

