### PR TITLE
feat: the invite learners button should render in the plan detail page

### DIFF
--- a/src/components/subscriptions/SubscriptionDetailContextProvider.jsx
+++ b/src/components/subscriptions/SubscriptionDetailContextProvider.jsx
@@ -15,7 +15,7 @@ const SubscriptionDetailContextProvider = ({ children, subscription }) => {
   const [activeTab, setActiveTab] = useState(TAB_ALL_USERS);
   const [currentPage, setCurrentPage] = useState(DEFAULT_PAGE);
   const [searchQuery, setSearchQuery] = useState(null);
-  const overview = useSubscriptionUsersOverview({
+  const [overview, forceRefresh] = useSubscriptionUsersOverview({
     subscriptionUUID: subscription.uuid,
     search: searchQuery,
     errors,
@@ -25,6 +25,7 @@ const SubscriptionDetailContextProvider = ({ children, subscription }) => {
     activeTab,
     currentPage,
     hasMultipleSubscriptions,
+    forceRefresh,
     overview,
     searchQuery,
     setActiveTab,

--- a/src/components/subscriptions/SubscriptionDetails.jsx
+++ b/src/components/subscriptions/SubscriptionDetails.jsx
@@ -21,8 +21,16 @@ const SubscriptionDetails = ({ enterpriseSlug }) => {
     setActiveTab,
     hasMultipleSubscriptions,
     subscription,
+    forceRefresh: forceDetailRefresh,
   } = useContext(SubscriptionDetailContext);
   const { addToast } = useContext(ToastsContext);
+
+  const isNonEmptyState = () => (
+    subscription.licenses?.allocated > 0
+    || subscription.licenses?.revoked > 0
+    || activeTab !== TAB_ALL_USERS
+  );
+
   return (
     <>
       {hasMultipleSubscriptions && (
@@ -40,11 +48,12 @@ const SubscriptionDetails = ({ enterpriseSlug }) => {
         <Col className="mb-3 mb-lg-0">
           <Row className="m-0 justify-content-between">
             <h2>{subscription?.title}</h2>
-            {(subscription.licenses?.allocated > 0 || activeTab !== TAB_ALL_USERS) && (
+            {isNonEmptyState() && (
               <div className="text-md-right">
                 <InviteLearnersButton
                   onSuccess={({ numAlreadyAssociated, numSuccessfulAssignments }) => {
                     forceRefresh();
+                    forceDetailRefresh();
                     addToast(`${numAlreadyAssociated} email addresses were previously assigned. ${numSuccessfulAssignments} email addresses were successfully added.`);
                     setActiveTab(TAB_PENDING_USERS);
                   }}

--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -92,6 +92,10 @@ export const useSubscriptionUsersOverview = ({
   };
   const [subscriptionUsersOverview, setSubscriptionUsersOverview] = useState(initialSubscriptionUsersOverview);
 
+  const forceRefresh = () => {
+    setSubscriptionUsersOverview({ ...subscriptionUsersOverview });
+  };
+
   useEffect(() => {
     if (subscriptionUUID) {
       LicenseManagerApiService.fetchSubscriptionUsersOverview(subscriptionUUID, { search })
@@ -115,7 +119,7 @@ export const useSubscriptionUsersOverview = ({
     }
   }, [subscriptionUUID, search]);
 
-  return subscriptionUsersOverview;
+  return [subscriptionUsersOverview, forceRefresh];
 };
 
 /*

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -130,7 +130,7 @@ export const mockUseSubscriptionUsers = (state) => ({
 
 export const SubscriptionManagementContext = ({ children, detailState, store }) => {
   jest.spyOn(hooks, 'useSubscriptionData').mockImplementation(() => mockUseSubscriptionData(detailState));
-  jest.spyOn(hooks, 'useSubscriptionUsersOverview').mockImplementation(() => detailState.overview);
+  jest.spyOn(hooks, 'useSubscriptionUsersOverview').mockImplementation(() => [detailState.overview, () => {}]);
   jest.spyOn(hooks, 'useSubscriptionUsers').mockImplementation(() => mockUseSubscriptionUsers(detailState));
   return (
     <Router history={initialHistory}>


### PR DESCRIPTION
...when there are no allocated licenses but there are revoked licenses.
ENT-4804

This also fixes a defect I noticed, where "Invite Learners" wasn't rendering in the All Users tab after inviting a learner - you'd have to do a full page refresh to see it.  I fixed this by adding a `forceRefresh()` function to the `SubscriptionDetailContext` context, which is now called by the `InviteLearnersButton.onSuccess()` handler (in addition to the forceRefresh of the subscription context for the entire agreement).

Testing:
* Create a new subscription plan
* Assign and then revoke a single license.
* On the plan details page, the "Invite Learners" button should still render at the top of the page when you're on the "All Users" tab (this is the fix).
