### PR TITLE
Subscription Management now using customer-agreement api

### DIFF
--- a/src/components/subscriptions/data/hooks.js
+++ b/src/components/subscriptions/data/hooks.js
@@ -47,6 +47,7 @@ export const useSubscriptions = ({ enterpriseId, errors, setErrors }) => {
               const flattenedSubscriptionResults = customerAgreement.subscriptions.map(subscription => ({
                 ...subscription,
                 showExpirationNotifications: !(customerAgreement.disableExpirationNotifications || false),
+                agreementNetDaysUntilExpiration: customerAgreement.netDaysUntilExpiration,
               }));
 
               subscriptionsData.results = subscriptionsData.results.concat(flattenedSubscriptionResults);

--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -14,12 +14,12 @@ import ContactCustomerSupportButton from '../buttons/ContactCustomerSupportButto
 
 const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
   const {
-    subscription: { daysUntilExpiration, expirationDate, showExpirationNotifications },
+    subscription: { agreementNetDaysUntilExpiration, expirationDate, showExpirationNotifications },
   } = useContext(SubscriptionDetailContext);
   const [showBanner, setShowBanner] = useState(true);
 
   const renderMessage = () => {
-    const subscriptionExpired = daysUntilExpiration <= 0;
+    const subscriptionExpired = agreementNetDaysUntilExpiration <= 0;
     // use subscription detail view messaging
     if (isSubscriptionPlanDetails) {
       return (
@@ -59,7 +59,7 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
             <Alert.Heading>
               Your subscription contract is expiring soon
             </Alert.Heading>
-            Your current subscription contract will expire in {daysUntilExpiration} days.
+            Your current subscription contract will expire in {agreementNetDaysUntilExpiration} days.
             Renew your subscription today to minimize access disruption for your learners.
           </>
         )}
@@ -67,18 +67,18 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
     );
   };
 
-  if (daysUntilExpiration > SUBSCRIPTION_DAYS_REMAINING_MODERATE) {
+  if (agreementNetDaysUntilExpiration > SUBSCRIPTION_DAYS_REMAINING_MODERATE) {
     return null;
   }
 
   let subscriptionExpirationThreshold = SUBSCRIPTION_DAYS_REMAINING_MODERATE;
   let dismissible = true;
   let alertType = 'info';
-  if (daysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
+  if (agreementNetDaysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
     subscriptionExpirationThreshold = SUBSCRIPTION_DAYS_REMAINING_SEVERE;
     alertType = 'warning';
   }
-  if (daysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL) {
+  if (agreementNetDaysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL) {
     subscriptionExpirationThreshold = SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL;
     dismissible = false;
     alertType = 'danger';
@@ -87,19 +87,19 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
   const emitAlertActionEvent = () => {
     sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.alert.support_cta.clicked', {
       expiration_threshold: subscriptionExpirationThreshold,
-      days_until_expiration: daysUntilExpiration,
+      days_until_expiration: agreementNetDaysUntilExpiration,
     });
   };
 
   const emitAlertDismissedEvent = () => {
     sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.alert.dismissed', {
       expiration_threshold: subscriptionExpirationThreshold,
-      days_until_expiration: daysUntilExpiration,
+      days_until_expiration: agreementNetDaysUntilExpiration,
     });
   };
 
   const actions = [];
-  if (!isSubscriptionPlanDetails || daysUntilExpiration > SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
+  if (!isSubscriptionPlanDetails || agreementNetDaysUntilExpiration > SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
     actions.push(<ContactCustomerSupportButton onClick={() => emitAlertActionEvent()} />);
   }
 
@@ -118,7 +118,7 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
       onClose={dismissBanner}
       actions={actions}
     >
-      {renderMessage(daysUntilExpiration)}
+      {renderMessage()}
     </Alert>
     )
   );

--- a/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
@@ -29,10 +29,10 @@ import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider'
 const SubscriptionExpirationModals = ({ enterpriseId }) => {
   const {
     subscription: {
-      daysUntilExpiration, showExpirationNotifications,
+      agreementNetDaysUntilExpiration, showExpirationNotifications,
     },
   } = useContext(SubscriptionDetailContext);
-  const isSubscriptionExpired = daysUntilExpiration <= 0;
+  const isSubscriptionExpired = agreementNetDaysUntilExpiration <= 0;
 
   /**
    * Computes a value representing the day thresolds in which the user should
@@ -46,15 +46,15 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
         SUBSCRIPTION_DAYS_REMAINING_MODERATE,
       ];
       // Finds the first expiration threshold (from most severe to least) that the current
-      // `daysUntilExpiration` falls into
-      return thresholds.find(threshold => threshold >= daysUntilExpiration);
+      // `agreementNetDaysUntilExpiration` falls into
+      return thresholds.find(threshold => threshold >= agreementNetDaysUntilExpiration);
     },
-    [daysUntilExpiration],
+    [agreementNetDaysUntilExpiration],
   );
 
   const shouldShowSubscriptionExpiringModal = useMemo(
     () => {
-      const isSubscriptionExpiring = daysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_MODERATE;
+      const isSubscriptionExpiring = agreementNetDaysUntilExpiration <= SUBSCRIPTION_DAYS_REMAINING_MODERATE;
 
       // expiring subscription modal should not be opened if the subscription is already expired, is not pending
       // expiration or a valid expiration threshold couldn't be found.
@@ -77,7 +77,7 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
 
       return true;
     },
-    [daysUntilExpiration, subscriptionExpirationThreshold, isSubscriptionExpired],
+    [agreementNetDaysUntilExpiration, subscriptionExpirationThreshold, isSubscriptionExpired],
   );
 
   const [isExpiredModalOpen, openExpiredModal, closeExpiredModal] = useToggle(isSubscriptionExpired);
@@ -98,14 +98,14 @@ const SubscriptionExpirationModals = ({ enterpriseId }) => {
   const emitAlertActionEvent = () => {
     sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.modal.support_cta.clicked', {
       expiration_threshold: subscriptionExpirationThreshold,
-      days_until_expiration: daysUntilExpiration,
+      days_until_expiration: agreementNetDaysUntilExpiration,
     });
   };
 
   const emitAlertDismissedEvent = () => {
     sendTrackEvent('edx.ui.admin_portal.subscriptions.expiration.modal.dismissed', {
       expiration_threshold: subscriptionExpirationThreshold,
-      days_until_expiration: daysUntilExpiration,
+      days_until_expiration: agreementNetDaysUntilExpiration,
     });
   };
 

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -17,7 +17,7 @@ const SubscriptionExpiringModal = ({
   enterpriseId,
   onAction,
 }) => {
-  const { subscription: { daysUntilExpiration, expirationDate } } = useContext(SubscriptionDetailContext);
+  const { subscription: { agreementNetDaysUntilExpiration, expirationDate } } = useContext(SubscriptionDetailContext);
 
   const handleClose = () => {
     if (expirationThreshold) {
@@ -48,7 +48,7 @@ const SubscriptionExpiringModal = ({
     >
       <ModalDialog.Header>
         <ModalDialog.Title>
-          Your subscription contract expires in {daysUntilExpiration} days
+          Your subscription contract expires in {agreementNetDaysUntilExpiration} days
         </ModalDialog.Title>
       </ModalDialog.Header>
 

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -17,8 +17,10 @@ const TEST_ENTERPRISE_CUSTOMER_UUID = 'b5f07fee-1b34-458f-b672-19b55fc1bd10';
 const TEST_ENTERPRISE_CUSTOMER_CATALOG_UUID = 'ff7acb5e-584a-4e5f-bacc-33a9995794f9';
 const TEST_SUBSCRIPTION_PLAN_TITLE = 'Test Subscription Plan';
 const TEST_SUBSCRIPTION_PLAN_UUID = '28d4dcdc-c026-4c02-a263-82dd9c0d8b43';
+
 export const SUBSCRIPTION_PLAN_ZERO_STATE = {
   daysUntilExpiration: 240,
+  agreementNetDaysUntilExpiration: 240,
   licenses: {
     total: 10,
     allocated: 0,
@@ -58,7 +60,9 @@ export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
   showExpirationNotifications: true,
 };
 const subscriptionPlan = (state) => {
-  const { daysUntilExpiration, licenses, showExpirationNotifications } = state;
+  const {
+    daysUntilExpiration, licenses, showExpirationNotifications, agreementNetDaysUntilExpiration,
+  } = state;
   return ({
     title: TEST_SUBSCRIPTION_PLAN_TITLE,
     uuid: TEST_SUBSCRIPTION_PLAN_UUID,
@@ -74,6 +78,7 @@ const subscriptionPlan = (state) => {
     },
     daysUntilExpiration,
     showExpirationNotifications,
+    agreementNetDaysUntilExpiration,
   });
 };
 

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
@@ -29,7 +29,11 @@ const ExpirationBannerWithContext = ({ detailState }) => (
 
 describe('<SubscriptionExpirationBanner />', () => {
   test('does not render an alert before the "moderate" days until expiration threshold', () => {
-    render(<ExpirationBannerWithContext detailState={SUBSCRIPTION_PLAN_ZERO_STATE} />);
+    const detailStateCopy = {
+      ...SUBSCRIPTION_PLAN_ZERO_STATE,
+      agreementNetDaysUntilExpiration: 240,
+    };
+    render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
@@ -40,7 +44,7 @@ describe('<SubscriptionExpirationBanner />', () => {
   ])('renders an alert after expiration threshold of %i', (threshold) => {
     const detailStateCopy = {
       ...SUBSCRIPTION_PLAN_ZERO_STATE,
-      daysUntilExpiration: threshold,
+      agreementNetDaysUntilExpiration: threshold,
     };
     render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
     expect(screen.queryByRole('alert')).not.toBeNull();
@@ -52,7 +56,7 @@ describe('<SubscriptionExpirationBanner />', () => {
   ])('expiration threshold %i is dismissible', async (threshold) => {
     const detailStateCopy = {
       ...SUBSCRIPTION_PLAN_ZERO_STATE,
-      daysUntilExpiration: threshold,
+      agreementNetDaysUntilExpiration: threshold,
     };
     render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
     expect(screen.queryByRole('alert')).not.toBeNull();
@@ -64,7 +68,7 @@ describe('<SubscriptionExpirationBanner />', () => {
   test('does not render an alert when subscription expiration notifications are disabled', () => {
     const detailStateCopy = {
       ...SUBSCRIPTION_PLAN_ZERO_STATE,
-      daysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_MODERATE,
+      agreementNetDaysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_MODERATE,
       showExpirationNotifications: false,
     };
     render(<ExpirationBannerWithContext detailState={detailStateCopy} />);

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
@@ -43,7 +43,7 @@ describe('<SubscriptionExpirationModals />', () => {
     test('render expired modal', () => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: 0,
+        agreementNetDaysUntilExpiration: 0,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
       expect(screen.queryByLabelText(EXPIRED_MODAL_TITLE)).toBeTruthy();
@@ -53,7 +53,7 @@ describe('<SubscriptionExpirationModals />', () => {
     test('do not render expired modal when expiration notifications are disabled', () => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: 0,
+        agreementNetDaysUntilExpiration: 0,
         showExpirationNotifications: false,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
@@ -64,7 +64,7 @@ describe('<SubscriptionExpirationModals />', () => {
     test('expired modal is dismissible', () => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: 0,
+        agreementNetDaysUntilExpiration: 0,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
       expect(screen.queryByLabelText(EXPIRED_MODAL_TITLE)).toBeTruthy();
@@ -81,7 +81,7 @@ describe('<SubscriptionExpirationModals />', () => {
     ])('render expiring modal for expiration threshold (%i days)', (threshold) => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: threshold,
+        agreementNetDaysUntilExpiration: threshold,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
       expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeTruthy();
@@ -91,7 +91,7 @@ describe('<SubscriptionExpirationModals />', () => {
     test('do not render expiring modal when expiration notifications are disabled', () => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+        agreementNetDaysUntilExpiration: SUBSCRIPTION_DAYS_REMAINING_SEVERE,
         showExpirationNotifications: false,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
@@ -106,7 +106,7 @@ describe('<SubscriptionExpirationModals />', () => {
     ])('close expiring modal for expiration threshold (%i days)', async (threshold) => {
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
-        daysUntilExpiration: threshold,
+        agreementNetDaysUntilExpiration: threshold,
       };
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
       expect(screen.queryByLabelText(EXPIRING_MODAL_TITLE)).toBeTruthy();


### PR DESCRIPTION
### [Closes ENT-4631](https://openedx.atlassian.net/browse/ENT-4631)

The purpose of this change is to make our subscription expiration modal/alert reminders to use a new field `netDaysUntilExpiration` coming from `/api/v1/customer-agreement/`, to better alert our users. 

Users will no longer be alerted if they have an upcoming/pending  subscription. They will only be notified about expiration when when the the last expiration date is within the expiration notification threshold (120 days).

Screenshot below show two plans, named `expired sub plan` and `expires later`. 

![Screen Shot 2021-08-17 at 4 57 07 PM](https://user-images.githubusercontent.com/6687387/129799626-9099e51a-8b16-4e0e-81be-f369067c446a.png)
 
If we navigate to `expired sub plan` detail view you will see no alert is being showed because we still have an ongoing plan `expires later`.
![Screen Shot 2021-08-17 at 4 53 36 PM](https://user-images.githubusercontent.com/6687387/129799875-031c0af3-02c4-40ba-9861-a5f908882d7b.png)

If both plans were expired or close to expiration however, a warning would be shown. 