### PR TITLE
feat: add purchase date to plan details

### DIFF
--- a/src/components/subscriptions/SubscriptionDetails.jsx
+++ b/src/components/subscriptions/SubscriptionDetails.jsx
@@ -60,6 +60,17 @@ const SubscriptionDetails = ({ enterpriseSlug }) => {
             )}
           </Row>
           <div className="mt-3 d-flex align-items-center">
+            {subscription.priorRenewals[0]?.priorSubscriptionPlanStartDate
+            && (
+            <div className="mr-5">
+              <div className="text-uppercase text-muted">
+                <small>Purchase Date</small>
+              </div>
+              <div className="lead">
+                {moment(subscription.priorRenewals[0].priorSubscriptionPlanStartDate).format('MMMM D, YYYY')}
+              </div>
+            </div>
+            )}
             <div className="mr-5">
               <div className="text-uppercase text-muted">
                 <small>Start Date</small>

--- a/src/components/subscriptions/tests/SubscriptionDetails.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionDetails.test.jsx
@@ -22,6 +22,7 @@ const defaultProps = {
 };
 
 const INVITE_LEARNERS_BUTTON_TEXT = 'Invite learners';
+const PURCHASE_DATE = 'Purchase Date';
 
 describe('SubscriptionDetails', () => {
   afterEach(() => {
@@ -104,6 +105,41 @@ describe('SubscriptionDetails', () => {
         </SubscriptionManagementContext>,
       );
       expect(screen.queryByText(INVITE_LEARNERS_BUTTON_TEXT)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('purchase date', () => {
+    it('should not show purchase date if there are no prior renewals', () => {
+      render(
+        <SubscriptionManagementContext detailState={{
+          ...SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+          prior_renewals: [],
+        }}
+        >
+          <SubscriptionDetails {...defaultProps} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.queryByText(PURCHASE_DATE)).not.toBeInTheDocument();
+    });
+
+    it('should show purchase date if there are prior renewals', () => {
+      render(
+        <SubscriptionManagementContext detailState={{
+          ...SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+          priorRenewals: [
+            {
+              priorSubscriptionPlanStartDate: '2021-08-25',
+              priorSubscriptionPlanId: '1',
+              renewedSubscriptionPlanId: '2',
+              renewedSubscriptionPlanStartDate: '2021-08-26',
+            },
+          ],
+        }}
+        >
+          <SubscriptionDetails {...defaultProps} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.queryByText(PURCHASE_DATE)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -34,6 +34,7 @@ export const SUBSCRIPTION_PLAN_ZERO_STATE = {
   },
   users: [],
   showExpirationNotifications: true,
+  priorRenewals: [],
 };
 export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
   daysUntilExpiration: 240,
@@ -58,11 +59,14 @@ export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
     },
   ],
   showExpirationNotifications: true,
+  priorRenewals: [],
 };
+
 const subscriptionPlan = (state) => {
   const {
-    daysUntilExpiration, licenses, showExpirationNotifications, agreementNetDaysUntilExpiration,
+    priorRenewals, daysUntilExpiration, licenses, showExpirationNotifications, agreementNetDaysUntilExpiration,
   } = state;
+
   return ({
     title: TEST_SUBSCRIPTION_PLAN_TITLE,
     uuid: TEST_SUBSCRIPTION_PLAN_UUID,
@@ -79,6 +83,7 @@ const subscriptionPlan = (state) => {
     daysUntilExpiration,
     showExpirationNotifications,
     agreementNetDaysUntilExpiration,
+    priorRenewals,
   });
 };
 
@@ -178,6 +183,14 @@ SubscriptionManagementContext.propTypes = {
       activationDate: PropTypes.string.isRequired,
       lastRemindDate: PropTypes.string.isRequired,
     })).isRequired,
+    priorRenewals: PropTypes.arrayOf(
+      PropTypes.shape({
+        priorSubscriptionPlanStartDate: PropTypes.string.isRequired,
+        priorSubscriptionPlanId: PropTypes.string.isRequired,
+        renewedSubscriptionPlanId: PropTypes.string.isRequired,
+        renewedSubscriptionPlanStartDate: PropTypes.string.isRequired,
+      }),
+    ),
   }).isRequired,
   store: PropTypes.shape(),
 };


### PR DESCRIPTION
[Link to the associated ticket
](https://openedx.atlassian.net/browse/ENT-3957)

Adding purchase date on subscription details as shown in miro.

<img width="1355" alt="Screen Shot 2021-08-30 at 10 36 04 AM" src="https://user-images.githubusercontent.com/17792243/131356653-f6d8bba9-c745-413f-b543-7e1b0fde9ec9.png">

Adding purchase date to subscription plan details (if needed).
