### PR TITLE
fix: disable admin actions on Subscription Plan locked for renewal processing

### DIFF
--- a/src/components/subscriptions/SubscriptionDetails.jsx
+++ b/src/components/subscriptions/SubscriptionDetails.jsx
@@ -25,9 +25,10 @@ const SubscriptionDetails = ({ enterpriseSlug }) => {
   } = useContext(SubscriptionDetailContext);
   const { addToast } = useContext(ToastsContext);
 
-  const shouldShowInviteLearnersButton = (subscription.licenses?.allocated > 0
-    || subscription.licenses?.revoked > 0
-    || activeTab !== TAB_ALL_USERS) && subscription.daysUntilExpiration > 0;
+  const hasLicensesAllocatedOrRevoked = subscription.licenses?.allocated > 0 || subscription.licenses?.revoked > 0;
+  const shouldShowInviteLearnersButton = (
+    (hasLicensesAllocatedOrRevoked || activeTab !== TAB_ALL_USERS) && subscription.daysUntilExpiration > 0
+  );
 
   return (
     <>
@@ -55,6 +56,7 @@ const SubscriptionDetails = ({ enterpriseSlug }) => {
                     addToast(`${numAlreadyAssociated} email addresses were previously assigned. ${numSuccessfulAssignments} email addresses were successfully added.`);
                     setActiveTab(TAB_PENDING_USERS);
                   }}
+                  disabled={subscription.isLockedForRenewalProcessing}
                 />
               </div>
             )}

--- a/src/components/subscriptions/data/constants.js
+++ b/src/components/subscriptions/data/constants.js
@@ -33,6 +33,8 @@ export const SHOW_REVOCATION_CAP_PERCENT = 80;
 export const SUBSCRIPTION_DAYS_REMAINING_MODERATE = 120;
 export const SUBSCRIPTION_DAYS_REMAINING_SEVERE = 60;
 export const SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL = 30;
+export const SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS = 12;
+
 // Prefix for cookies that determine if the user has seen the modal for that range of expiration
 export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';
 

--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -7,6 +7,7 @@ import {
   SUBSCRIPTION_DAYS_REMAINING_MODERATE,
   SUBSCRIPTION_DAYS_REMAINING_SEVERE,
   SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
+  SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS,
 } from '../data/constants';
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import { formatTimestamp } from '../../../utils';
@@ -38,8 +39,8 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
               <Alert.Heading>
                 This subscription plan&apos;s end date is approaching
               </Alert.Heading>
-              Administrative actions will no longer be available following the
-              plan end date of {formatTimestamp({ timestamp: expirationDate })}.
+              Administrative actions will no longer be available beginning {SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS}
+              {' '}hours prior to the plan end date of {formatTimestamp({ timestamp: expirationDate })}.
             </>
           )}
         </>

--- a/src/components/subscriptions/tests/SubscriptionDetails.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionDetails.test.jsx
@@ -106,6 +106,28 @@ describe('SubscriptionDetails', () => {
       );
       expect(screen.queryByText(INVITE_LEARNERS_BUTTON_TEXT)).not.toBeInTheDocument();
     });
+
+    it('should not be disabled if the subscription is not locked for renewal processing', () => {
+      render(
+        <SubscriptionManagementContext detailState={SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE}>
+          <SubscriptionDetails {...defaultProps} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.getByText(INVITE_LEARNERS_BUTTON_TEXT)).not.toBeDisabled();
+    });
+
+    it('should be disabled if the subscription is locked for renewal processing', () => {
+      render(
+        <SubscriptionManagementContext detailState={{
+          ...SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+          isLockedForRenewalProcessing: true,
+        }}
+        >
+          <SubscriptionDetails {...defaultProps} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.getByText(INVITE_LEARNERS_BUTTON_TEXT)).toBeDisabled();
+    });
   });
 
   describe('purchase date', () => {

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -35,9 +35,11 @@ export const SUBSCRIPTION_PLAN_ZERO_STATE = {
   users: [],
   showExpirationNotifications: true,
   priorRenewals: [],
+  isLockedForRenewalProcessing: false,
 };
 export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
   daysUntilExpiration: 240,
+  agreementNetDaysUntilExpiration: 240,
   licenses: {
     total: 10,
     allocated: 1,
@@ -60,11 +62,17 @@ export const SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE = {
   ],
   showExpirationNotifications: true,
   priorRenewals: [],
+  isLockedForRenewalProcessing: false,
 };
 
 const subscriptionPlan = (state) => {
   const {
-    priorRenewals, daysUntilExpiration, licenses, showExpirationNotifications, agreementNetDaysUntilExpiration,
+    priorRenewals,
+    daysUntilExpiration,
+    licenses,
+    showExpirationNotifications,
+    agreementNetDaysUntilExpiration,
+    isLockedForRenewalProcessing,
   } = state;
 
   return ({
@@ -84,6 +92,7 @@ const subscriptionPlan = (state) => {
     showExpirationNotifications,
     agreementNetDaysUntilExpiration,
     priorRenewals,
+    isLockedForRenewalProcessing,
   });
 };
 

--- a/src/components/subscriptions/tests/licenses/LicenseActions.test.jsx
+++ b/src/components/subscriptions/tests/licenses/LicenseActions.test.jsx
@@ -1,0 +1,90 @@
+import {
+  screen,
+  cleanup,
+  render,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import React from 'react';
+import LicenseActions from '../../licenses/LicenseActions';
+import {
+  SubscriptionManagementContext, SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+} from '../TestUtilities';
+
+describe('LicenseActions', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('activated license status', () => {
+    const licensedUser = { status: 'activated' };
+
+    it('should only render revoke button when subscription is not locked', () => {
+      render(
+        <SubscriptionManagementContext detailState={SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE}>
+          <LicenseActions user={licensedUser} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.getByText('Revoke'));
+      expect(screen.queryByText('Remind')).not.toBeInTheDocument();
+    });
+
+    it('should not render any buttons when subscription is locked', () => {
+      render(
+        <SubscriptionManagementContext
+          detailState={{
+            ...SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+            isLockedForRenewalProcessing: true,
+          }}
+        >
+          <LicenseActions user={licensedUser} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.queryByText('Remind')).not.toBeInTheDocument();
+      expect(screen.queryByText('Revoke')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('assigned license status', () => {
+    const licensedUser = { status: 'assigned' };
+
+    it('should render both remind and revoke buttons when subscription is not locked', () => {
+      render(
+        <SubscriptionManagementContext detailState={SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE}>
+          <LicenseActions user={licensedUser} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.getByText('Remind'));
+      expect(screen.getByText('Revoke'));
+    });
+
+    it('should render only remind when subscription is locked', () => {
+      render(
+        <SubscriptionManagementContext
+          detailState={{
+            ...SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE,
+            isLockedForRenewalProcessing: true,
+          }}
+        >
+          <LicenseActions user={licensedUser} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.getByText('Remind'));
+      expect(screen.queryByText('Revoke')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('revoked license status', () => {
+    const licensedUser = { status: 'revoked' };
+
+    it('should render neither remind nor revoke buttons', () => {
+      render(
+        <SubscriptionManagementContext detailState={SUBSCRIPTION_PLAN_ASSIGNED_USER_STATE}>
+          <LicenseActions user={licensedUser} />
+        </SubscriptionManagementContext>,
+      );
+      expect(screen.queryByText('Remind')).not.toBeInTheDocument();
+      expect(screen.queryByText('Revoke')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Ticket: [ENT-4837](https://openedx.atlassian.net/browse/ENT-4837)

Reads the `is_locked_for_renewal_processing` field from license-manager's `SubscriptionPlanSerializer` to determine whether admin actions (i.e., inviting learners, revoking license) are disabled/present.

### Testing instructions

1. Ensure `is_locked_for_renewal_processing` is returned by the `subscriptions` API endpoint in license-manager.
2. In license-manager, create a subscription plan that expires within a couple hours and an associated subscription plan renewal that has an effective date of shortly after the existing subscription plan (within the next 12 hours).
3. Load the subscription detail route; observe the "Invite learners" button is disabled and the "Revoke" action is removed from rows of users who have an assigned license. Related, see that the expiration approaching alert messaging is updated.