### PR TITLE
fix: revoke emails should also redirect to learner portal

### DIFF
--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -18,7 +18,7 @@ import {
 } from '../CodeModal';
 import EmailTemplateForm from '../EmailTemplateForm';
 import CheckboxWithTooltip from '../ReduxFormCheckbox/CheckboxWithTooltip';
-import { features } from '../../config';
+import { configuration, features } from '../../config';
 
 const ERROR_MESSAGE_TITLES = {
   [MODAL_TYPES.revoke]: 'Unable to revoke code(s)',
@@ -92,6 +92,8 @@ class CodeRevokeModal extends React.Component {
       isBulkRevoke,
       data,
       sendCodeRevoke,
+      enterpriseSlug,
+      enableLearnerPortal,
     } = this.props;
 
     const { doNotEmail } = this.state;
@@ -117,6 +119,11 @@ class CodeRevokeModal extends React.Component {
       }),
       do_not_email: doNotEmail,
     };
+
+    // If the enterprise has a learner portal, we should direct users to it in our revoke email
+    if (enableLearnerPortal && configuration.ENTERPRISE_LEARNER_PORTAL_URL) {
+      options.base_enterprise_url = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}`;
+    }
 
     if (formData['template-id']) {
       options.template_id = formData['template-id'];
@@ -266,6 +273,9 @@ CodeRevokeModal.defaultProps = {
 };
 
 CodeRevokeModal.propTypes = {
+  // props from redux
+  enterpriseSlug: PropTypes.string.isRequired,
+  enableLearnerPortal: PropTypes.bool.isRequired,
   // props From redux-form
   handleSubmit: PropTypes.func.isRequired,
   submitting: PropTypes.bool.isRequired,

--- a/src/containers/CodeRevokeModal/index.jsx
+++ b/src/containers/CodeRevokeModal/index.jsx
@@ -12,6 +12,8 @@ const mapStateToProps = (state) => {
   return {
     initialValues,
     enableReinitialize: true,
+    enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+    enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
   };
 };
 


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-4886

Actual: Revoke emails do not redirect to learner portal if learner portal is enabled in enterprise configuration.
Expected: It should redirect to learner portal if learner portal is enabled, otherwise to B2B search page. 