### PR TITLE
chore: use bulk-revoke endpoint to revoke licenses

### DIFF
--- a/src/components/LicenseRevokeModal/index.jsx
+++ b/src/components/LicenseRevokeModal/index.jsx
@@ -44,7 +44,8 @@ class LicenseRevokeModal extends React.Component {
       sendLicenseRevoke,
       subscriptionPlan,
     } = this.props;
-    const options = { user_email: user.userEmail };
+
+    const options = { user_emails: [user.userEmail] };
 
     return sendLicenseRevoke(subscriptionPlan.uuid, options)
       .then(response => this.props.onSuccess(response))

--- a/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
+++ b/src/containers/LicenseRevokeModal/LicenseRevokeModal.test.jsx
@@ -63,7 +63,7 @@ describe('LicenseRevokeModalWrapper', () => {
   });
 
   it('renders license revoke modal', () => {
-    spy = jest.spyOn(LicenseManagerApiService, 'licenseRevoke');
+    spy = jest.spyOn(LicenseManagerApiService, 'licenseBulkRevoke');
 
     const wrapper = mount(<LicenseRevokeModalWrapper user={user} />);
     expect(wrapper.find('.modal-title').text()).toEqual('Are you sure you want to revoke this license?');

--- a/src/data/actions/licenseRevoke.js
+++ b/src/data/actions/licenseRevoke.js
@@ -33,10 +33,10 @@ const sendLicenseRevoke = ({
 }) => (
   (dispatch) => {
     dispatch(sendLicenseRevokeRequest());
-    return LicenseManagerApiService.licenseRevoke(subscriptionUUID, options)
+    return LicenseManagerApiService.licenseBulkRevoke(subscriptionUUID, options)
       .then((response) => {
         dispatch(sendLicenseRevokeSuccess(response));
-        onSuccess(response);
+        onSuccess();
       })
       .catch((error) => {
         logError(error);

--- a/src/data/services/LicenseManagerAPIService.js
+++ b/src/data/services/LicenseManagerAPIService.js
@@ -138,8 +138,8 @@ class LicenseManagerApiService {
     return LicenseManagerApiService.apiClient().get(url);
   }
 
-  static licenseRevoke(subscriptionUUID, options) {
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/revoke/`;
+  static licenseBulkRevoke(subscriptionUUID, options) {
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/subscriptions/${subscriptionUUID}/licenses/bulk-revoke/`;
     return LicenseManagerApiService.apiClient().post(url, options);
   }
 


### PR DESCRIPTION
Deprecating the /revoke and moving towards /bulk-revoke to remove redundancy. New endpoint will be used for the new table as well.

https://openedx.atlassian.net/browse/ENT-4737

