### PR TITLE
fix: show correct expiration banner on subscription details page

### DIFF
--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -54,7 +54,7 @@ const SubscriptionExpiringModal = ({
 
       <ModalDialog.Body>
         <p>
-          It&apos;s time to renew your subscription contact with edX!
+          It&apos;s time to renew your subscription contract with edX!
           The edX customer support team is here to help.
           Get in touch today to minimize access disruptions for your learners.
         </p>

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
@@ -21,9 +21,9 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
 
 // PropType validation for state is done by SubscriptionManagementContext
 // eslint-disable-next-line react/prop-types
-const ExpirationBannerWithContext = ({ detailState }) => (
+const ExpirationBannerWithContext = ({ detailState, isSubscriptionPlanDetails = false }) => (
   <SubscriptionManagementContext detailState={detailState}>
-    <SubscriptionExpirationBanner />
+    <SubscriptionExpirationBanner isSubscriptionPlanDetails={isSubscriptionPlanDetails} />
   </SubscriptionManagementContext>
 );
 
@@ -73,5 +73,28 @@ describe('<SubscriptionExpirationBanner />', () => {
     };
     render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test.each([
+    true,
+    false,
+  ])('renders the correct message when isSubscriptionPlanDetails = %s', (isSubscriptionPlanDetails) => {
+    const detailStateCopy = {
+      ...SUBSCRIPTION_PLAN_ZERO_STATE,
+      agreementNetDaysUntilExpiration: 0,
+      daysUntilExpiration: 0,
+    };
+    render(<ExpirationBannerWithContext
+      detailState={detailStateCopy}
+      isSubscriptionPlanDetails={isSubscriptionPlanDetails}
+    />);
+
+    if (isSubscriptionPlanDetails) {
+      expect(screen.getByText("This subscription plan's end date has passed"));
+      expect(screen.queryByText('Your subscription contract has expired')).toBeNull();
+    } else {
+      expect(screen.getByText('Your subscription contract has expired'));
+      expect(screen.queryByText("This subscription plan's end date has passed")).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-4883

- Fix banner behavior to match https://miro.com/app/board/o9J_kglry8E=/?moveToWidget=3074457359742106696&cot=14
  on subscription details
- Fix typo in expiration modal

![Screen Shot 2021-09-20 at 11 04 46 AM](https://user-images.githubusercontent.com/17792243/134032048-a09e7a8f-5efb-4549-adee-494be94f4cdc.png)

