### PR TITLE
chore: switch to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,8 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Coverage
+      uses: codecov/codecov-action@v2
     - name: Build
       run: npm run build
     - name: Verify is ES5

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # frontend-app-admin-portal
 
 ![Build Status](https://github.com/edx/frontend-app-admin-portal/actions/workflows/ci.yml/badge.svg)
-![Coveralls](https://img.shields.io/coveralls/edx/frontend-app-admin-portal.svg?branch=master)
+![Codecov](https://codecov.io/gh/edx/frontend-app-admin-portal/branch/master/graph/badge.svg)
 
 ## Overview
 frontend-app-admin-portal is a frontend that provides branded learning experiences as well as a dashboard for enterprise learning administrators.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7164,19 +7164,6 @@
         "yaml": "^1.7.2"
       }
     },
-    "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -13841,12 +13828,6 @@
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14072,12 +14053,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true
     },
     "logalot": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "build:gh-pages": "NODE_ENV=development BABEL_ENV=development webpack --config=config/webpack.dev.config.js",
-    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "deploy:gh-pages": "npm run build:gh-pages && gh-pages -d dist",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
@@ -90,7 +89,6 @@
     "@testing-library/dom": "7.31.2",
     "@testing-library/react-hooks": "5.0.3",
     "codecov": "3.7.1",
-    "coveralls": "3.1.0",
     "css-loader": "3.5.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",


### PR DESCRIPTION
"The majority of the edX micro-frontends and JS libraries are using Codecov instead of Coveralls these days. Coveralls has been down all morning today (blocking the release of a patch version in this repository), which was inspiration for getting Paragon to use Codecov instead." - Adam Stanckiewicz