### PR TITLE
Table Actions Clear Selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2513,9 +2513,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "16.14.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.14.5.tgz",
-      "integrity": "sha512-L/s3x5b6icoCtb0KFXrPiO3GePr+/qgIejaaMbhmrSz5GKmBfJvg5qv2Fm0bB1S2V7iM4+LaxpNF9DyOqRWQJw==",
+      "version": "16.16.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.16.0.tgz",
+      "integrity": "sha512-fl4zTZQfv0lJ9v4PdzRitOaS87ftQrCmvg2cEe9IXlrkIhpgrSTST6YKbvVVu4PBGokgX6YuXeEvzkP4hMOIhg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -4114,9 +4114,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
-      "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@edx/frontend-enterprise-logistration": "0.1.11",
     "@edx/frontend-enterprise-utils": "1.1.0",
     "@edx/frontend-platform": "1.11.0",
-    "@edx/paragon": "^16.14.5",
+    "@edx/paragon": "^16.16.0",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",
     "@fortawesome/free-regular-svg-icons": "5.15.3",

--- a/src/components/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
+++ b/src/components/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
@@ -22,7 +22,6 @@ exports[`<ErrorPage /> renders correctly 1`] = `
           >
             <svg
               aria-hidden={true}
-              aria-label=""
               fill="none"
               focusable={false}
               height={24}
@@ -85,14 +84,18 @@ exports[`<ErrorPage /> renders correctly for 403 errors 1`] = `
           <p>
             For assistance, please contact the edX Customer Success team at
              
-            <a
-              className="default-link standalone-link"
-              href="mailto:customersuccess@edx.org"
-              onClick={null}
-              target="_self"
+            <span
+              className="pgn__mailtolink"
             >
-              customersuccess@edx.org
-            </a>
+              <a
+                className="pgn__hyperlink default-link standalone-link"
+                href="mailto:customersuccess@edx.org"
+                onClick={null}
+                target="_self"
+              >
+                customersuccess@edx.org
+              </a>
+            </span>
             .
           </p>
         </div>

--- a/src/components/ForbiddenPage/__snapshots__/ForbiddenPage.test.jsx.snap
+++ b/src/components/ForbiddenPage/__snapshots__/ForbiddenPage.test.jsx.snap
@@ -21,14 +21,18 @@ exports[`<ForbiddenPage /> renders correctly 1`] = `
       <p>
         For assistance, please contact the edX Customer Success team at
          
-        <a
-          className="default-link standalone-link"
-          href="mailto:customersuccess@edx.org"
-          onClick={null}
-          target="_self"
+        <span
+          className="pgn__mailtolink"
         >
-          customersuccess@edx.org
-        </a>
+          <a
+            className="pgn__hyperlink default-link standalone-link"
+            href="mailto:customersuccess@edx.org"
+            onClick={null}
+            target="_self"
+          >
+            customersuccess@edx.org
+          </a>
+        </span>
         .
       </p>
     </div>

--- a/src/components/SupportPage/__snapshots__/SupportPage.test.jsx.snap
+++ b/src/components/SupportPage/__snapshots__/SupportPage.test.jsx.snap
@@ -29,14 +29,18 @@ Array [
         <p>
           For assistance, please contact the edX Customer Success team at
            
-          <a
-            className="default-link standalone-link"
-            href="mailto:customersuccess@edx.org"
-            onClick={null}
-            target="_self"
+          <span
+            className="pgn__mailtolink"
           >
-            customersuccess@edx.org
-          </a>
+            <a
+              className="pgn__hyperlink default-link standalone-link"
+              href="mailto:customersuccess@edx.org"
+              onClick={null}
+              target="_self"
+            >
+              customersuccess@edx.org
+            </a>
+          </span>
           .
         </p>
       </div>

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementModalHook.js
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementModalHook.js
@@ -16,4 +16,25 @@ export const useRequestState = (isOpen) => {
   return [requestState, setRequestState, initialRequestState];
 };
 
+export const licenseManagementModalZeroState = {
+  isOpen: false,
+  users: [],
+  allUsersSelected: false,
+};
+
+/**
+ * Handles basic modal open/close usage and can hold user data
+ * @param initialState shape:
+ * {
+ *  isOpen: bool
+ *  users: array
+ *  allUsersSelected: bool
+ * }
+ * @returns [state, setState, zeroState]
+ */
+export const useLicenseManagementModalState = (initialState = licenseManagementModalZeroState) => {
+  const [modalState, setModalState] = useState(initialState);
+  return [modalState, setModalState, licenseManagementModalZeroState];
+};
+
 export default useRequestState;

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
@@ -1,30 +1,69 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   IconButton,
   Icon,
   Tooltip,
   OverlayTrigger,
+  DataTableContext,
 } from '@edx/paragon';
 import {
   Email,
   RemoveCircle,
 } from '@edx/paragon/icons';
 
+import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
+import LicenseManagementRemindModal from '../LicenseManagementModals/LicenseManagementRemindModal';
 import { canRemindLicense, canRevokeLicense } from '../../data/utils';
+import {
+  useLicenseManagementModalState,
+  licenseManagementModalZeroState as modalZeroState,
+} from '../LicenseManagementModals/LicenseManagementModalHook';
 
 const revokeText = 'Revoke license';
 const remindText = 'Remind learner';
 
 const LicenseManagementTableActionColumn = ({
   user,
-  rowRemindOnClick,
-  rowRevokeOnClick,
+  subscription,
+  onRemindSuccess,
+  onRevokeSuccess,
   disabled,
 }) => {
   const displayRemind = canRemindLicense(user.status);
   const displayRevoked = canRevokeLicense(user.status);
 
+  const [revokeModal, setRevokeModal] = useLicenseManagementModalState();
+  const [remindModal, setRemindModal] = useLicenseManagementModalState();
+  const { clearSelection } = useContext(DataTableContext);
+
+  const revokeOnClick = (revokeUser) => {
+    setRevokeModal({
+      ...revokeModal,
+      isOpen: true,
+      users: [revokeUser],
+    });
+  };
+
+  const remindOnClick = (remindUser) => {
+    setRemindModal({
+      ...remindModal,
+      isOpen: true,
+      users: [remindUser],
+    });
+  };
+
+  const handleRevokeSuccess = () => {
+    setRevokeModal(modalZeroState);
+    onRevokeSuccess(clearSelection)();
+  };
+
+  const handleRemindSuccess = () => {
+    setRemindModal(modalZeroState);
+    onRemindSuccess(clearSelection)();
+  };
+
+  // console.log('letContext',letContext)
   return (
     <>
       {displayRemind
@@ -43,7 +82,7 @@ const LicenseManagementTableActionColumn = ({
           src={Email}
           iconAs={Icon}
           variant="secondary"
-          onClick={() => rowRemindOnClick(user)}
+          onClick={() => remindOnClick(user)}
           disabled={disabled}
         />
       </OverlayTrigger>
@@ -65,12 +104,27 @@ const LicenseManagementTableActionColumn = ({
           style={{ marginLeft: displayRemind ? 0 : 44 }}
           iconAs={Icon}
           variant="danger"
-          onClick={() => rowRevokeOnClick(user)}
+          onClick={() => revokeOnClick(user)}
           disabled={disabled}
         />
       </OverlayTrigger>
       )}
-
+      <LicenseManagementRevokeModal
+        isOpen={revokeModal.isOpen}
+        usersToRevoke={revokeModal.users}
+        subscription={subscription}
+        onClose={() => setRevokeModal(modalZeroState)}
+        onSuccess={handleRevokeSuccess}
+        revokeAllUsers={revokeModal.allUsersSelected}
+      />
+      <LicenseManagementRemindModal
+        isOpen={remindModal.isOpen}
+        usersToRemind={remindModal.users}
+        subscription={subscription}
+        onClose={() => setRemindModal(modalZeroState)}
+        onSuccess={handleRemindSuccess}
+        remindAllUsers={remindModal.allUsersSelected}
+      />
     </>
   );
 };
@@ -80,11 +134,20 @@ LicenseManagementTableActionColumn.defaultProps = {
 };
 
 LicenseManagementTableActionColumn.propTypes = {
+  subscription: PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    expirationDate: PropTypes.string.isRequired,
+    isRevocationCapEnabled: PropTypes.bool.isRequired,
+    revocations: PropTypes.shape({
+      applied: PropTypes.number.isRequired,
+      remaining: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
   user: PropTypes.shape({
     status: PropTypes.string.isRequired,
   }).isRequired,
-  rowRemindOnClick: PropTypes.func.isRequired,
-  rowRevokeOnClick: PropTypes.func.isRequired,
+  onRemindSuccess: PropTypes.func.isRequired,
+  onRevokeSuccess: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
 };
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
@@ -13,7 +13,6 @@ import {
 import { canRemindLicense, canRevokeLicense } from '../../data/utils';
 import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
 import LicenseManagementRemindModal from '../LicenseManagementModals/LicenseManagementRemindModal';
-
 import {
   useLicenseManagementModalState,
   licenseManagementModalZeroState as modalZeroState,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   ActionRow, Button, Icon, ModalPopup, useToggle,
 } from '@edx/paragon';
-
 import {
   BookOpen,
   Email,
@@ -12,19 +11,31 @@ import {
 } from '@edx/paragon/icons';
 
 import { canRemindLicense, canRevokeLicense } from '../../data/utils';
+import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
+import LicenseManagementRemindModal from '../LicenseManagementModals/LicenseManagementRemindModal';
+
+import {
+  useLicenseManagementModalState,
+  licenseManagementModalZeroState as modalZeroState,
+} from '../LicenseManagementModals/LicenseManagementModalHook';
 
 const LicenseManagementTableBulkActions = ({
+  subscription,
   enrollmentLink,
   selectedUsers,
-  bulkRemindOnClick,
-  bulkRevokeOnClick,
+  onRemindSuccess,
+  onRevokeSuccess,
   allUsersSelected,
   activatedUsers,
   assignedUsers,
   disabled,
 }) => {
+  const [revokeModal, setRevokeModal] = useLicenseManagementModalState();
+  const [remindModal, setRemindModal] = useLicenseManagementModalState();
+
   const [isOpen, open, close] = useToggle(false);
   const target = React.useRef(null);
+
   // Divides selectedUsers users into two arrays
   const [usersToRemind, usersToRevoke] = useMemo(() => {
     if (allUsersSelected) {
@@ -46,44 +57,90 @@ const LicenseManagementTableBulkActions = ({
     return [tempRemind, tempRevoke];
   }, [selectedUsers, allUsersSelected]);
 
+  const revokeOnClick = (revokeUsers) => {
+    setRevokeModal({
+      isOpen: true,
+      users: revokeUsers,
+      allUsersSelected,
+    });
+  };
+
+  const remindOnClick = (remindUsers) => {
+    setRemindModal({
+      isOpen: true,
+      users: remindUsers,
+      allUsersSelected,
+    });
+  };
+
+  const handleRevokeSuccess = () => {
+    setRevokeModal(modalZeroState);
+    onRevokeSuccess();
+  };
+
+  const handleRemindSuccess = () => {
+    setRemindModal(modalZeroState);
+    onRemindSuccess();
+  };
+
   return (
-    <ActionRow>
-      <Button
-        ref={target}
-        variant="tertiary"
-        onClick={open}
-        data-testid="revokeToggle"
-      >
-        <Icon src={MoreVert} />
-      </Button>
-      <ModalPopup positionRef={target} isOpen={isOpen} onClose={close}>
-        <div className="bg-white p-3 rounded shadow">
-          <Button
-            variant="outline-danger"
-            iconBefore={RemoveCircle}
-            onClick={() => bulkRevokeOnClick(usersToRevoke, allUsersSelected)}
-            disabled={(!usersToRevoke.length && !allUsersSelected) || disabled}
-          >
-            Revoke ({allUsersSelected ? activatedUsers + assignedUsers : usersToRevoke.length})
-          </Button>
-        </div>
-      </ModalPopup>
-      <Button
-        variant="outline-primary"
-        iconBefore={Email}
-        onClick={() => bulkRemindOnClick(usersToRemind, allUsersSelected)}
-        disabled={(!usersToRemind.length && !allUsersSelected) || disabled}
-      >
-        Remind ({allUsersSelected ? assignedUsers : usersToRemind.length })
-      </Button>
-      <Button
-        variant="primary"
-        href={enrollmentLink}
-        iconBefore={BookOpen}
-      >
-        Enroll
-      </Button>
-    </ActionRow>
+    <>
+      <ActionRow>
+        <Button
+          ref={target}
+          variant="tertiary"
+          onClick={open}
+          data-testid="revokeToggle"
+        >
+          <Icon src={MoreVert} />
+        </Button>
+        <ModalPopup positionRef={target} isOpen={isOpen} onClose={close}>
+          <div>
+            <Button
+              variant="outline-danger"
+              iconBefore={RemoveCircle}
+              onClick={() => revokeOnClick(usersToRevoke, allUsersSelected)}
+              disabled={(!usersToRevoke.length && !allUsersSelected) || disabled}
+            >
+              Revoke ({allUsersSelected ? activatedUsers + assignedUsers : usersToRevoke.length})
+            </Button>
+          </div>
+        </ModalPopup>
+        <Button
+          variant="outline-primary"
+          iconBefore={Email}
+          onClick={() => remindOnClick(usersToRemind)}
+          disabled={(!usersToRemind.length && !allUsersSelected) || disabled}
+        >
+          Remind ({allUsersSelected ? assignedUsers : usersToRemind.length })
+        </Button>
+        <Button
+          variant="primary"
+          href={enrollmentLink}
+          iconBefore={BookOpen}
+        >
+          Enroll
+        </Button>
+      </ActionRow>
+      <LicenseManagementRevokeModal
+        isOpen={revokeModal.isOpen}
+        usersToRevoke={revokeModal.users}
+        subscription={subscription}
+        onClose={() => setRevokeModal(modalZeroState)}
+        onSuccess={handleRevokeSuccess}
+        revokeAllUsers={revokeModal.allUsersSelected}
+        totalToRevoke={activatedUsers + assignedUsers}
+      />
+      <LicenseManagementRemindModal
+        isOpen={remindModal.isOpen}
+        usersToRemind={remindModal.users}
+        subscription={subscription}
+        onClose={() => setRemindModal(modalZeroState)}
+        onSuccess={handleRemindSuccess}
+        remindAllUsers={remindModal.allUsersSelected}
+        totalToRemind={assignedUsers}
+      />
+    </>
   );
 };
 
@@ -92,14 +149,23 @@ LicenseManagementTableBulkActions.defaultProps = {
 };
 
 LicenseManagementTableBulkActions.propTypes = {
+  subscription: PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    expirationDate: PropTypes.string.isRequired,
+    isRevocationCapEnabled: PropTypes.bool.isRequired,
+    revocations: PropTypes.shape({
+      applied: PropTypes.number.isRequired,
+      remaining: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
   enrollmentLink: PropTypes.string.isRequired,
   selectedUsers: PropTypes.arrayOf(
     PropTypes.shape({
       status: PropTypes.string.isRequired,
     }).isRequired,
   ).isRequired,
-  bulkRemindOnClick: PropTypes.func.isRequired,
-  bulkRevokeOnClick: PropTypes.func.isRequired,
+  onRemindSuccess: PropTypes.func.isRequired,
+  onRevokeSuccess: PropTypes.func.isRequired,
   allUsersSelected: PropTypes.bool.isRequired,
   activatedUsers: PropTypes.number.isRequired,
   assignedUsers: PropTypes.number.isRequired,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -131,14 +131,6 @@ const LicenseManagementTable = () => {
     [users],
   );
 
-  // Row action button functions
-  const rowRemindOnClick = (remindUser) => {
-    console.log(remindUser);
-  };
-  const rowRevokeOnClick = (revokeUser) => {
-    console.log(revokeUser);
-  };
-
   // Successful action modal callback
   const onRemindSuccess = (clearTableSelectionCallback) => (() => {
     clearTableSelectionCallback();
@@ -230,9 +222,10 @@ const LicenseManagementTable = () => {
             Cell: ({ row }) => (
               <LicenseManagementTableActionColumn
                 user={row.original}
-                rowRemindOnClick={rowRemindOnClick}
-                rowRevokeOnClick={rowRevokeOnClick}
+                subscription={subscription}
                 disabled={isExpired}
+                onRemindSuccess={onRemindSuccess}
+                onRevokeSuccess={onRevokeSuccess}
               />
               /* eslint-enable */
             ),

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useMemo, useContext, useState,
+  useCallback, useMemo, useContext,
 } from 'react';
 import {
   DataTable,
@@ -21,8 +21,6 @@ import { ToastsContext } from '../../../Toasts';
 import { formatTimestamp } from '../../../../utils';
 import SubscriptionZeroStateMessage from '../../SubscriptionZeroStateMessage';
 import DownloadCsvButton from '../../buttons/DownloadCsvButton';
-import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
-import LicenseManagementRemindModal from '../LicenseManagementModals/LicenseManagementRemindModal';
 import LicenseManagementTableBulkActions from './LicenseManagementTableBulkActions';
 import LicenseManagementTableActionColumn from './LicenseManagementTableActionColumn';
 import LicenseManagementUserBadge from './LicenseManagementUserBadge';
@@ -51,16 +49,7 @@ const selectColumn = {
   disableSortBy: true,
 };
 
-const modalZeroState = {
-  open: false,
-  users: [],
-  allUsersSelected: false,
-};
-
 const LicenseManagementTable = () => {
-  const [remindModal, setRemindModal] = useState(modalZeroState);
-  const [revokeModal, setRevokeModal] = useState(modalZeroState);
-
   const { addToast } = useContext(ToastsContext);
 
   const { width } = useWindowSize();
@@ -144,48 +133,26 @@ const LicenseManagementTable = () => {
 
   // Row action button functions
   const rowRemindOnClick = (remindUser) => {
-    setRemindModal({
-      open: true,
-      users: [remindUser],
-    });
+    console.log(remindUser);
   };
   const rowRevokeOnClick = (revokeUser) => {
-    setRevokeModal({
-      open: true,
-      users: [revokeUser],
-    });
+    console.log(revokeUser);
   };
 
   // Successful action modal callback
-  const onRemindSuccess = () => {
+  const onRemindSuccess = (clearTableSelectionCallback) => (() => {
+    clearTableSelectionCallback();
     forceRefreshUsers();
-    setRemindModal(modalZeroState);
-    addToast(`User${revokeModal.users.length > 1 ? 's' : ''} successfully reminded`);
-  };
-  const onRevokeSuccess = () => {
+    addToast('Users successfully reminded');
+  });
+  const onRevokeSuccess = (clearTableSelectionCallback) => (() => {
     // refresh subscription and user data to get updated revoke count and revoked user list
+    clearTableSelectionCallback();
     forceRefreshSubscription();
     forceRefreshUsers();
     forceRefreshOverview();
-    setRevokeModal(modalZeroState);
-    addToast(`License${revokeModal.users.length > 1 ? 's' : ''} successfully revoked`);
-  };
-
-  // Bulk Action buttons
-  const bulkRemindOnClick = (usersToRemind, allUsersSelected) => {
-    setRemindModal({
-      open: true,
-      users: usersToRemind,
-      allUsersSelected,
-    });
-  };
-  const bulkRevokeOnClick = (usersToRevoke, allUsersSelected) => {
-    setRevokeModal({
-      open: true,
-      users: usersToRevoke,
-      allUsersSelected,
-    });
-  };
+    addToast('Licenses successfully revoked');
+  });
 
   const showSubscriptionZeroStateMessage = subscription.licenses.total === subscription.licenses.unassigned;
   return (
@@ -273,12 +240,14 @@ const LicenseManagementTable = () => {
         ]}
         bulkActions={(data) => {
           const selectedUsers = data.selectedFlatRows.map((selectedRow) => selectedRow.original);
+          const { clearSelection } = data.tableInstance;
           return (
             <LicenseManagementTableBulkActions
+              subscription={subscription}
               enrollmentLink={enrollmentLink}
               selectedUsers={selectedUsers}
-              bulkRemindOnClick={bulkRemindOnClick}
-              bulkRevokeOnClick={bulkRevokeOnClick}
+              onRemindSuccess={onRemindSuccess(clearSelection)}
+              onRevokeSuccess={onRevokeSuccess(clearSelection)}
               activatedUsers={overview.activated}
               assignedUsers={overview.assigned}
               allUsersSelected={data.isEntireTableSelected}
@@ -286,25 +255,6 @@ const LicenseManagementTable = () => {
             />
           );
         }}
-      />
-
-      <LicenseManagementRevokeModal
-        isOpen={revokeModal.open}
-        usersToRevoke={revokeModal.users}
-        subscription={subscription}
-        onClose={() => setRevokeModal(modalZeroState)}
-        onSuccess={onRevokeSuccess}
-        revokeAllUsers={revokeModal.allUsersSelected}
-        totalToRevoke={overview.activated + overview.assigned}
-      />
-      <LicenseManagementRemindModal
-        isOpen={remindModal.open}
-        usersToRemind={remindModal.users}
-        subscription={subscription}
-        onClose={() => setRemindModal(modalZeroState)}
-        onSuccess={onRemindSuccess}
-        remindAllUsers={remindModal.allUsersSelected}
-        totalToRemind={overview.assigned}
       />
     </>
   );

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import {
+  act,
   screen,
   render,
   cleanup,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import moment from 'moment';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 
 import LicenseManagementTableActionColumn from '../LicenseManagementTableActionColumn';
 import {
@@ -12,51 +17,112 @@ import {
   REVOKED,
 } from '../../../data/constants';
 
-const assignedTestUser = { status: ASSIGNED };
-const activatedTestUser = { status: ACTIVATED };
-const revokedTestUser = { status: REVOKED };
-const fooTestUser = { status: 'foo' };
+const mockStore = configureMockStore();
+const store = mockStore({
+  portalConfiguration: {
+    enterpriseId: 'test-enterprise-id',
+  },
+});
+
+const email = 'foo@test.edx.org';
+const assignedTestUser = { status: ASSIGNED, email };
+const activatedTestUser = { status: ACTIVATED, email };
+const revokedTestUser = { status: REVOKED, email };
+const fooTestUser = { status: 'foo', email };
 
 const basicProps = {
   user: assignedTestUser,
-  rowRemindOnClick: () => {},
-  rowRevokeOnClick: () => {},
+  onRemindSuccess: () => {},
+  onRevokeSuccess: () => {},
+  subscription: {
+    uuid: '1',
+    expirationDate: moment().add(1, 'days').format(),
+    isRevocationCapEnabled: false,
+    revocations: {
+      applied: 0,
+      remaining: 10,
+    },
+  },
 };
+
+const LicenseManagementTableActionColumnWithContext = (props) => (
+  <Provider store={store}>
+    <LicenseManagementTableActionColumn {...props} />
+  </Provider>
+);
 
 describe('<LicenseManagementTableActionColumn />', () => {
   afterEach(() => {
     cleanup();
-    jest.clearAllMocks();
+  });
+  const testDialogClosed = () => {
+    const cancelButton = screen.getByText('Cancel');
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+  };
+
+  describe('renders buttons when', () => {
+    it(`user status ${ASSIGNED}`, () => {
+      render(<LicenseManagementTableActionColumnWithContext {...basicProps} />);
+      expect(screen.getAllByRole('button').length).toBe(2);
+      expect(screen.getByTitle('Remind learner')).toBeTruthy();
+      expect(screen.getByTitle('Revoke license')).toBeTruthy();
+    });
+
+    it(`user status ${ACTIVATED}`, () => {
+      const props = { ...basicProps, user: activatedTestUser };
+      render(<LicenseManagementTableActionColumnWithContext {...props} />);
+      expect(screen.getAllByRole('button').length).toBe(1);
+      expect(screen.queryByTitle('Remind learner')).toBeFalsy();
+      expect(screen.queryByTitle('Revoke license')).toBeTruthy();
+    });
+
+    it(`user status ${REVOKED}`, () => {
+      const props = { ...basicProps, user: revokedTestUser };
+      render(<LicenseManagementTableActionColumnWithContext {...props} />);
+      expect(screen.queryAllByRole('button').length).toBe(0);
+      expect(screen.queryByTitle('Remind learner')).toBeFalsy();
+      expect(screen.queryByTitle('Revoke license')).toBeFalsy();
+    });
+
+    it('user status undefined', () => {
+      const props = { ...basicProps, user: fooTestUser };
+      render(<LicenseManagementTableActionColumnWithContext {...props} />);
+      expect(screen.queryAllByRole('button').length).toBe(0);
+      expect(screen.queryByTitle('Remind learner')).toBeFalsy();
+      expect(screen.queryByTitle('Revoke license')).toBeFalsy();
+    });
   });
 
-  it(`renders both buttons when user status ${ASSIGNED}`, () => {
-    render(<LicenseManagementTableActionColumn {...basicProps} />);
-    expect(screen.getAllByRole('button').length).toBe(2);
-    expect(screen.getByTitle('Remind learner')).toBeTruthy();
-    expect(screen.getByTitle('Revoke license')).toBeTruthy();
+  it('opens and closes revoke modal', async () => {
+    render(<LicenseManagementTableActionColumnWithContext {...basicProps} />);
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+    // Open dialog
+    const revokeButton = screen.getByTitle('Revoke license');
+    await act(async () => {
+      await userEvent.click(revokeButton);
+    });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // Close dialog
+    const cancelButton = screen.getByText('Cancel');
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+    expect(screen.queryByRole('dialog')).toBeFalsy();
   });
 
-  it(`renders both buttons when user status ${ACTIVATED}`, () => {
-    const props = { ...basicProps, user: activatedTestUser };
-    render(<LicenseManagementTableActionColumn {...props} />);
-    expect(screen.getAllByRole('button').length).toBe(1);
-    expect(screen.queryByTitle('Remind learner')).toBeFalsy();
-    expect(screen.queryByTitle('Revoke license')).toBeTruthy();
-  });
-
-  it(`renders both buttons when user status ${REVOKED}`, () => {
-    const props = { ...basicProps, user: revokedTestUser };
-    render(<LicenseManagementTableActionColumn {...props} />);
-    expect(screen.queryAllByRole('button').length).toBe(0);
-    expect(screen.queryByTitle('Remind learner')).toBeFalsy();
-    expect(screen.queryByTitle('Revoke license')).toBeFalsy();
-  });
-
-  it('renders both buttons when user status undefined', () => {
-    const props = { ...basicProps, user: fooTestUser };
-    render(<LicenseManagementTableActionColumn {...props} />);
-    expect(screen.queryAllByRole('button').length).toBe(0);
-    expect(screen.queryByTitle('Remind learner')).toBeFalsy();
-    expect(screen.queryByTitle('Revoke license')).toBeFalsy();
+  it('opens and closes remind modal', async () => {
+    render(<LicenseManagementTableActionColumnWithContext {...basicProps} />);
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+    // Open dialog
+    const remindButton = screen.getByTitle('Remind learner');
+    await act(async () => {
+      await userEvent.click(remindButton);
+    });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // Close dialog
+    testDialogClosed();
   });
 });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
@@ -6,6 +6,9 @@ import {
   cleanup,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import moment from 'moment';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 
 import LicenseManagementTableBulkActions from '../LicenseManagementTableBulkActions';
 import {
@@ -14,19 +17,41 @@ import {
   REVOKED,
 } from '../../../data/constants';
 
+const mockStore = configureMockStore();
+const store = mockStore({
+  portalConfiguration: {
+    enterpriseId: 'test-enterprise-id',
+  },
+});
+
 const basicProps = {
   selectedUsers: [],
-  bulkRemindOnClick: () => {},
-  bulkRevokeOnClick: () => {},
+  onRemindSuccess: () => {},
+  onRevokeSuccess: () => {},
   allUsersSelected: false,
   activatedUsers: 0,
   assignedUsers: 0,
+  subscription: {
+    uuid: '1',
+    expirationDate: moment().add(1, 'days').format(),
+    isRevocationCapEnabled: false,
+    revocations: {
+      applied: 0,
+      remaining: 10,
+    },
+  },
 };
 
 const testAssignedUser = { status: ASSIGNED };
 const testActivatedUser = { status: ACTIVATED };
 const testRevokedUser = { status: REVOKED };
 const testUndefinedUser = { status: 'foo' };
+
+const LicenseManagementTableBulkActionsWithContext = (props) => (
+  <Provider store={store}>
+    <LicenseManagementTableBulkActions {...props} />
+  </Provider>
+);
 
 describe('<LicenseManagementTableBulkActions />', () => {
   afterEach(() => {
@@ -35,7 +60,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
   });
 
   it('renders correct empty state', () => {
-    render(<LicenseManagementTableBulkActions {...basicProps} />);
+    render(<LicenseManagementTableBulkActionsWithContext {...basicProps} />);
     expect(screen.getAllByRole('button').length).toBe(3);
     expect(screen.getByText('Enroll')).toBeTruthy();
     expect(screen.getByText('Remind (0)')).toBeTruthy();
@@ -45,7 +70,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
   describe('renders correct label when not all users are selected ', () => {
     it('selected only revoked users', () => {
       const props = { ...basicProps, selectedUsers: [testRevokedUser, testRevokedUser] };
-      render(<LicenseManagementTableBulkActions {...props} />);
+      render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
@@ -56,7 +81,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     });
     it('selected only activated users', () => {
       const props = { ...basicProps, selectedUsers: [testActivatedUser] };
-      render(<LicenseManagementTableBulkActions {...props} />);
+      render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
@@ -67,7 +92,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     });
     it('selected only assigned users', () => {
       const props = { ...basicProps, selectedUsers: [testAssignedUser, testAssignedUser] };
-      render(<LicenseManagementTableBulkActions {...props} />);
+      render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (2)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
@@ -78,7 +103,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     });
     it('selected mix users', () => {
       const props = { ...basicProps, selectedUsers: [testRevokedUser, testActivatedUser, testAssignedUser] };
-      render(<LicenseManagementTableBulkActions {...props} />);
+      render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (1)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
@@ -89,7 +114,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     });
     it('selected undefined users', () => {
       const props = { ...basicProps, selectedUsers: [testUndefinedUser] };
-      render(<LicenseManagementTableBulkActions {...props} />);
+      render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
@@ -97,6 +122,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
       expect(screen.getByText('Revoke (0)')).toBeTruthy();
     });
   });
+
   it('renders correct label when all users are selected', () => {
     const props = {
       ...basicProps,
@@ -104,7 +130,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
       activatedUsers: 1,
       assignedUsers: 1,
     };
-    render(<LicenseManagementTableBulkActions {...props} />);
+    render(<LicenseManagementTableBulkActionsWithContext {...props} />);
     expect(screen.getByText('Enroll')).toBeTruthy();
     expect(screen.getByText('Remind (1)')).toBeTruthy();
     const revokeMenu = screen.getByTestId('revokeToggle');
@@ -112,5 +138,44 @@ describe('<LicenseManagementTableBulkActions />', () => {
       userEvent.click(revokeMenu);
     });
     expect(screen.getByText('Revoke (2)')).toBeTruthy();
+  });
+
+  it('opens and closes remind modal', () => {
+    const props = { ...basicProps, selectedUsers: [testAssignedUser] };
+    render(<LicenseManagementTableBulkActionsWithContext {...props} />);
+    // open dialog
+    const remindButton = screen.getByText('Remind (1)');
+    act(() => {
+      userEvent.click(remindButton);
+    });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // close dialog
+    const cancelButton = screen.getByText('Cancel');
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+  });
+
+  it('opens and closes revoke modal', () => {
+    const props = { ...basicProps, selectedUsers: [testAssignedUser] };
+    render(<LicenseManagementTableBulkActionsWithContext {...props} />);
+    // reveal revoke menu
+    const revokeMenu = screen.getByTestId('revokeToggle');
+    act(() => {
+      userEvent.click(revokeMenu);
+    });
+    // open dialog
+    const revokeButton = screen.getByText('Revoke (1)');
+    act(() => {
+      userEvent.click(revokeButton);
+    });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // close dialog
+    const cancelButton = screen.getByText('Cancel');
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+    expect(screen.queryByRole('dialog')).toBeFalsy();
   });
 });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
@@ -40,12 +40,14 @@ const basicProps = {
       remaining: 10,
     },
   },
+  enrollmentLink: 'link',
 };
 
-const testAssignedUser = { status: ASSIGNED };
-const testActivatedUser = { status: ACTIVATED };
-const testRevokedUser = { status: REVOKED };
-const testUndefinedUser = { status: 'foo' };
+const email = 'foo@test.edx.org';
+const testAssignedUser = { status: ASSIGNED, email };
+const testActivatedUser = { status: ACTIVATED, email };
+const testRevokedUser = { status: REVOKED, email };
+const testUndefinedUser = { status: 'foo', email };
 
 const LicenseManagementTableBulkActionsWithContext = (props) => (
   <Provider store={store}>
@@ -58,72 +60,81 @@ describe('<LicenseManagementTableBulkActions />', () => {
     cleanup();
     jest.clearAllMocks();
   });
+  const testDialogClosed = () => {
+    const cancelButton = screen.getByText('Cancel');
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+  };
 
   it('renders correct empty state', () => {
     render(<LicenseManagementTableBulkActionsWithContext {...basicProps} />);
-    expect(screen.getAllByRole('button').length).toBe(3);
+    expect(screen.getAllByRole('button').length).toBe(2);
     expect(screen.getByText('Enroll')).toBeTruthy();
     expect(screen.getByText('Remind (0)')).toBeTruthy();
     expect(screen.getByTestId('revokeToggle')).toBeTruthy();
   });
 
   describe('renders correct label when not all users are selected ', () => {
-    it('selected only revoked users', () => {
+    it('selected only revoked users', async () => {
       const props = { ...basicProps, selectedUsers: [testRevokedUser, testRevokedUser] };
       render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
-      act(() => {
-        userEvent.click(revokeMenu);
+      await act(async () => {
+        await userEvent.click(revokeMenu);
       });
       expect(screen.getByText('Revoke (0)')).toBeTruthy();
     });
-    it('selected only activated users', () => {
+    it('selected only activated users', async () => {
       const props = { ...basicProps, selectedUsers: [testActivatedUser] };
       render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
-      act(() => {
-        userEvent.click(revokeMenu);
+      await act(async () => {
+        await userEvent.click(revokeMenu);
       });
       expect(screen.getByText('Revoke (1)')).toBeTruthy();
     });
-    it('selected only assigned users', () => {
+    it('selected only assigned users', async () => {
       const props = { ...basicProps, selectedUsers: [testAssignedUser, testAssignedUser] };
       render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (2)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
-      act(() => {
-        userEvent.click(revokeMenu);
+      await act(async () => {
+        await userEvent.click(revokeMenu);
       });
       expect(screen.getByText('Revoke (2)')).toBeTruthy();
     });
-    it('selected mix users', () => {
+    it('selected mix users', async () => {
       const props = { ...basicProps, selectedUsers: [testRevokedUser, testActivatedUser, testAssignedUser] };
       render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (1)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
-      act(() => {
-        userEvent.click(revokeMenu);
+      await act(async () => {
+        await userEvent.click(revokeMenu);
       });
       expect(screen.getByText('Revoke (2)')).toBeTruthy();
     });
-    it('selected undefined users', () => {
+    it('selected undefined users', async () => {
       const props = { ...basicProps, selectedUsers: [testUndefinedUser] };
       render(<LicenseManagementTableBulkActionsWithContext {...props} />);
       expect(screen.getByText('Enroll')).toBeTruthy();
       expect(screen.getByText('Remind (0)')).toBeTruthy();
       const revokeMenu = screen.getByTestId('revokeToggle');
-      userEvent.click(revokeMenu);
+      await act(async () => {
+        await userEvent.click(revokeMenu);
+      });
       expect(screen.getByText('Revoke (0)')).toBeTruthy();
     });
   });
 
-  it('renders correct label when all users are selected', () => {
+  it('renders correct label when all users are selected', async () => {
     const props = {
       ...basicProps,
       allUsersSelected: true,
@@ -134,48 +145,40 @@ describe('<LicenseManagementTableBulkActions />', () => {
     expect(screen.getByText('Enroll')).toBeTruthy();
     expect(screen.getByText('Remind (1)')).toBeTruthy();
     const revokeMenu = screen.getByTestId('revokeToggle');
-    act(() => {
-      userEvent.click(revokeMenu);
+    await act(async () => {
+      await userEvent.click(revokeMenu);
     });
     expect(screen.getByText('Revoke (2)')).toBeTruthy();
   });
 
-  it('opens and closes remind modal', () => {
+  it('opens and closes remind modal', async () => {
     const props = { ...basicProps, selectedUsers: [testAssignedUser] };
     render(<LicenseManagementTableBulkActionsWithContext {...props} />);
-    // open dialog
+    // Open dialog
     const remindButton = screen.getByText('Remind (1)');
-    act(() => {
-      userEvent.click(remindButton);
+    await act(async () => {
+      await userEvent.click(remindButton);
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
-    // close dialog
-    const cancelButton = screen.getByText('Cancel');
-    act(() => {
-      userEvent.click(cancelButton);
-    });
-    expect(screen.queryByRole('dialog')).toBeFalsy();
+    // Close dialog
+    testDialogClosed();
   });
 
-  it('opens and closes revoke modal', () => {
+  it('opens and closes revoke modal', async () => {
     const props = { ...basicProps, selectedUsers: [testAssignedUser] };
     render(<LicenseManagementTableBulkActionsWithContext {...props} />);
-    // reveal revoke menu
+    // Reveal revoke menu
     const revokeMenu = screen.getByTestId('revokeToggle');
-    act(() => {
-      userEvent.click(revokeMenu);
+    await act(async () => {
+      await userEvent.click(revokeMenu);
     });
-    // open dialog
+    // Open dialog
     const revokeButton = screen.getByText('Revoke (1)');
-    act(() => {
+    await act(async () => {
       userEvent.click(revokeButton);
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
-    // close dialog
-    const cancelButton = screen.getByText('Cancel');
-    act(() => {
-      userEvent.click(cancelButton);
-    });
-    expect(screen.queryByRole('dialog')).toBeFalsy();
+    // Close dialog
+    testDialogClosed();
   });
 });

--- a/src/containers/SaveTemplateButton/__snapshots__/SaveTemplateButton.test.jsx.snap
+++ b/src/containers/SaveTemplateButton/__snapshots__/SaveTemplateButton.test.jsx.snap
@@ -13,9 +13,7 @@ exports[`<SaveTemplateButton /> renders correctly in disabled state 1`] = `
     className="d-flex align-items-center justify-content-center"
   >
     <span>
-       
       Save Template
-       
     </span>
   </span>
 </button>
@@ -34,9 +32,7 @@ exports[`<SaveTemplateButton /> renders correctly in enabled state 1`] = `
     className="d-flex align-items-center justify-content-center"
   >
     <span>
-       
       Save Template
-       
     </span>
   </span>
 </button>
@@ -55,9 +51,7 @@ exports[`<SaveTemplateButton /> renders correctly while saving a template 1`] = 
     className="d-flex align-items-center justify-content-center"
   >
     <span>
-       
       Save Template
-       
     </span>
   </span>
 </button>


### PR DESCRIPTION
# Context

This change contains no visual changes. 

In the subscription detail page, if admins selected users on the table and clicked reminded or revoked user licenses actions, their selection would be remain. This change:

1. Updates paragon library dependency
2. Rearranges components so that they are under the `DataTable` context umbrella allowing them to use the `clearSelection` function of the `DataTableContext` provider. 
3. Updated some tests and added new tests to cover some of the modal state management that shifted around.

Now revoking and reminding users will clear the table selection the user may have had.

Cloeses [ENT-5060](https://openedx.atlassian.net/browse/ENT-5060)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [] Ensure to attach screenshots
- [] Ensure to have UX team confirm screenshots
