### PR TITLE
Subscription management table events

### DIFF
--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
@@ -59,6 +59,7 @@ const LicenseManagementRemindModal = ({
   isOpen,
   onClose,
   onSuccess,
+  onSubmit,
   subscription,
   usersToRemind,
   remindAllUsers,
@@ -75,6 +76,9 @@ const LicenseManagementRemindModal = ({
   const title = `Remind User${remindAllUsers || usersToRemind.length > 1 ? 's' : ''}`;
 
   const handleSubmit = () => {
+    if (onSubmit) {
+      onSubmit();
+    }
     setRequestState({ ...initialRequestState, loading: true });
     try {
       validateEmailTemplateForm(emailTemplate, 'body', false);
@@ -214,12 +218,16 @@ LicenseManagementRemindModal.defaultProps = {
   remindAllUsers: false,
   totalToRemind: -1,
   contactEmail: null,
+  onSubmit: undefined,
 };
 
 LicenseManagementRemindModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  /** Function executed after successful remind request resolved */
   onSuccess: PropTypes.func.isRequired,
+  /** Function executed when submit button is pressed */
+  onSubmit: PropTypes.func,
   subscription: PropTypes.shape({
     uuid: PropTypes.string.isRequired,
     expirationDate: PropTypes.string.isRequired,

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
@@ -66,6 +66,7 @@ const LicenseManagementRevokeModal = ({
   isOpen,
   onClose,
   onSuccess,
+  onSubmit,
   subscription,
   usersToRevoke,
   revokeAllUsers,
@@ -84,6 +85,9 @@ const LicenseManagementRevokeModal = ({
   const isExpired = moment().isAfter(subscription.expirationDate);
 
   const handleSubmit = () => {
+    if (onSubmit) {
+      onSubmit();
+    }
     setRequestState({ ...initialRequestState, loading: true });
     const makeRequest = () => {
       if (revokeAllUsers) {
@@ -192,12 +196,16 @@ const LicenseManagementRevokeModal = ({
 LicenseManagementRevokeModal.defaultProps = {
   revokeAllUsers: false,
   totalToRevoke: -1,
+  onSubmit: undefined,
 };
 
 LicenseManagementRevokeModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  /** Function executed after successful remind request resolved */
   onSuccess: PropTypes.func.isRequired,
+  /** Function executed when submit button is pressed */
+  onSubmit: PropTypes.func,
   subscription: PropTypes.shape({
     uuid: PropTypes.string.isRequired,
     expirationDate: PropTypes.string.isRequired,

--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
@@ -28,10 +28,12 @@ jest.mock('../../../../../data/services/LicenseManagerAPIService', () => ({
   },
 }));
 
+const onSubmitMock = jest.fn();
 const basicProps = {
   isOpen: true,
   onClose: () => {},
   onSuccess: () => {},
+  onSubmit: onSubmitMock,
   subscription: {
     uuid: 'lorem',
     expirationDate: moment().add(1, 'days').format(), // tomorrow
@@ -105,6 +107,7 @@ describe('<LicenseManagementRemindModal />', () => {
 
       const button = screen.getByText('Remind (1)');
       await act(async () => { userEvent.click(button); });
+      expect(onSubmitMock).toBeCalledTimes(1);
 
       expect(screen.queryByText('Remind (1)')).toBeFalsy();
       expect(screen.queryByText('Done')).toBeTruthy();
@@ -122,6 +125,7 @@ describe('<LicenseManagementRemindModal />', () => {
 
       const button = screen.getByText('Remind (1)');
       await act(async () => { userEvent.click(button); });
+      expect(onSubmitMock).toBeCalledTimes(1);
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();

--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRevokeModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRevokeModal.test.jsx
@@ -21,10 +21,12 @@ jest.mock('../../../../../data/services/LicenseManagerAPIService', () => ({
   },
 }));
 
+const onSubmitMock = jest.fn();
 const basicProps = {
   isOpen: true,
   onClose: () => {},
   onSuccess: () => {},
+  onSubmit: onSubmitMock,
   subscription: {
     uuid: 'lorem',
     expirationDate: moment().add(1, 'days').format(), // tomorrow
@@ -97,6 +99,7 @@ describe('<LicenseManagementRevokeModal />', () => {
 
       const button = screen.getByText('Revoke (1)');
       await act(async () => { userEvent.click(button); });
+      expect(onSubmitMock).toBeCalledTimes(1);
 
       expect(screen.queryByText('Revoke (1)')).toBeFalsy();
       expect(screen.queryByText('Done')).toBeTruthy();
@@ -114,6 +117,7 @@ describe('<LicenseManagementRevokeModal />', () => {
 
       const button = screen.getByText('Revoke (1)');
       await act(async () => { userEvent.click(button); });
+      expect(onSubmitMock).toBeCalledTimes(1);
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();
@@ -131,8 +135,8 @@ describe('<LicenseManagementRevokeModal />', () => {
 
       const button = screen.getByText('Revoke (All)');
       await act(async () => { userEvent.click(button); });
+      expect(onSubmitMock).toBeCalledTimes(1);
 
-      // await act(() => mockPromiseReject)
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();
       });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
@@ -20,7 +20,7 @@ import {
   useLicenseManagementModalState,
   licenseManagementModalZeroState as modalZeroState,
 } from '../LicenseManagementModals/LicenseManagementModalHook';
-import { subscriptionsTableEventNames } from '../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../eventTracking';
 
 const revokeText = 'Revoke license';
 const remindText = 'Remind learner';
@@ -47,7 +47,7 @@ const LicenseManagementTableActionColumn = ({
     });
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeRowClick,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_ROW_CLICK,
     );
   };
 
@@ -59,7 +59,7 @@ const LicenseManagementTableActionColumn = ({
     });
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindRowClick,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_ROW_CLICK,
     );
   };
 
@@ -76,14 +76,14 @@ const LicenseManagementTableActionColumn = ({
   const handleRevokeSubmit = () => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeRowSubmit,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_ROW_SUBMIT,
     );
   };
 
   const handleRemindSubmit = () => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindRowSubmit,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_ROW_SUBMIT,
     );
   };
 
@@ -91,7 +91,7 @@ const LicenseManagementTableActionColumn = ({
     setRevokeModal(modalZeroState);
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeRowCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_ROW_CANCEL,
     );
   };
 
@@ -99,7 +99,7 @@ const LicenseManagementTableActionColumn = ({
     setRemindModal(modalZeroState);
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindRowCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_ROW_CANCEL,
     );
   };
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
@@ -12,6 +12,7 @@ import {
   RemoveCircle,
 } from '@edx/paragon/icons';
 
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
 import LicenseManagementRemindModal from '../LicenseManagementModals/LicenseManagementRemindModal';
 import { canRemindLicense, canRevokeLicense } from '../../data/utils';
@@ -19,6 +20,7 @@ import {
   useLicenseManagementModalState,
   licenseManagementModalZeroState as modalZeroState,
 } from '../LicenseManagementModals/LicenseManagementModalHook';
+import { subscriptionsTableEventNames } from '../../../../eventTracking';
 
 const revokeText = 'Revoke license';
 const remindText = 'Remind learner';
@@ -43,6 +45,10 @@ const LicenseManagementTableActionColumn = ({
       isOpen: true,
       users: [revokeUser],
     });
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeRowClick,
+    );
   };
 
   const remindOnClick = (remindUser) => {
@@ -51,6 +57,10 @@ const LicenseManagementTableActionColumn = ({
       isOpen: true,
       users: [remindUser],
     });
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindRowClick,
+    );
   };
 
   const handleRevokeSuccess = () => {
@@ -61,6 +71,36 @@ const LicenseManagementTableActionColumn = ({
   const handleRemindSuccess = () => {
     setRemindModal(modalZeroState);
     onRemindSuccess(clearSelection)();
+  };
+
+  const handleRevokeSubmit = () => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeRowSubmit,
+    );
+  };
+
+  const handleRemindSubmit = () => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindRowSubmit,
+    );
+  };
+
+  const handleRevokeCancel = () => {
+    setRevokeModal(modalZeroState);
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeRowCancel,
+    );
+  };
+
+  const handleRemindCancel = () => {
+    setRemindModal(modalZeroState);
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindRowCancel,
+    );
   };
 
   return (
@@ -112,16 +152,18 @@ const LicenseManagementTableActionColumn = ({
         isOpen={revokeModal.isOpen}
         usersToRevoke={revokeModal.users}
         subscription={subscription}
-        onClose={() => setRevokeModal(modalZeroState)}
+        onClose={handleRevokeCancel}
         onSuccess={handleRevokeSuccess}
+        onSubmit={handleRevokeSubmit}
         revokeAllUsers={revokeModal.allUsersSelected}
       />
       <LicenseManagementRemindModal
         isOpen={remindModal.isOpen}
         usersToRemind={remindModal.users}
         subscription={subscription}
-        onClose={() => setRemindModal(modalZeroState)}
+        onClose={handleRemindCancel}
         onSuccess={handleRemindSuccess}
+        onSubmit={handleRemindSubmit}
         remindAllUsers={remindModal.allUsersSelected}
       />
     </>
@@ -134,6 +176,7 @@ LicenseManagementTableActionColumn.defaultProps = {
 
 LicenseManagementTableActionColumn.propTypes = {
   subscription: PropTypes.shape({
+    enterpriseCustomerUuid: PropTypes.string.isRequired,
     uuid: PropTypes.string.isRequired,
     expirationDate: PropTypes.string.isRequired,
     isRevocationCapEnabled: PropTypes.bool.isRequired,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
@@ -18,7 +18,7 @@ import {
   useLicenseManagementModalState,
   licenseManagementModalZeroState as modalZeroState,
 } from '../LicenseManagementModals/LicenseManagementModalHook';
-import { subscriptionsTableEventNames } from '../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../eventTracking';
 
 const LicenseManagementTableBulkActions = ({
   subscription,
@@ -66,7 +66,7 @@ const LicenseManagementTableBulkActions = ({
     });
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeBulkClick,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_CLICK,
       {
         selected_users: revokeUsers.length,
         all_users_selected: allUsersSelected,
@@ -82,7 +82,7 @@ const LicenseManagementTableBulkActions = ({
     });
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindBulkClick,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_BULK_CLICK,
       {
         selected_users: remindUsers.length,
         all_users_selected: allUsersSelected,
@@ -103,7 +103,7 @@ const LicenseManagementTableBulkActions = ({
   const handleRemindSubmit = () => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindBulkSubmit,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_SUBMIT,
       {
         selected_users: remindModal.users.length,
         all_users_selected: remindModal.allUsersSelected,
@@ -114,7 +114,7 @@ const LicenseManagementTableBulkActions = ({
   const handleRevokeSubmit = () => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeBulkSubmit,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_SUBMIT,
       {
         selected_users: revokeModal.users.length,
         all_users_selected: revokeModal.allUsersSelected,
@@ -126,7 +126,7 @@ const LicenseManagementTableBulkActions = ({
     setRemindModal(modalZeroState);
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.remindBulkCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_BULK_CANCEL,
       {
         selected_users: remindModal.users.length,
         all_users_selected: remindModal.allUsersSelected,
@@ -138,7 +138,7 @@ const LicenseManagementTableBulkActions = ({
     setRevokeModal(modalZeroState);
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.revokeBulkCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_CANCEL,
       {
         selected_users: revokeModal.users.length,
         all_users_selected: revokeModal.allUsersSelected,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableBulkActions.jsx
@@ -9,6 +9,7 @@ import {
   RemoveCircle,
   MoreVert,
 } from '@edx/paragon/icons';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { canRemindLicense, canRevokeLicense } from '../../data/utils';
 import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';
@@ -17,6 +18,7 @@ import {
   useLicenseManagementModalState,
   licenseManagementModalZeroState as modalZeroState,
 } from '../LicenseManagementModals/LicenseManagementModalHook';
+import { subscriptionsTableEventNames } from '../../../../eventTracking';
 
 const LicenseManagementTableBulkActions = ({
   subscription,
@@ -62,6 +64,14 @@ const LicenseManagementTableBulkActions = ({
       users: revokeUsers,
       allUsersSelected,
     });
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeBulkClick,
+      {
+        selected_users: revokeUsers.length,
+        all_users_selected: allUsersSelected,
+      },
+    );
   };
 
   const remindOnClick = (remindUsers) => {
@@ -70,6 +80,14 @@ const LicenseManagementTableBulkActions = ({
       users: remindUsers,
       allUsersSelected,
     });
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindBulkClick,
+      {
+        selected_users: remindUsers.length,
+        all_users_selected: allUsersSelected,
+      },
+    );
   };
 
   const handleRevokeSuccess = () => {
@@ -80,6 +98,52 @@ const LicenseManagementTableBulkActions = ({
   const handleRemindSuccess = () => {
     setRemindModal(modalZeroState);
     onRemindSuccess();
+  };
+
+  const handleRemindSubmit = () => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindBulkSubmit,
+      {
+        selected_users: remindModal.users.length,
+        all_users_selected: remindModal.allUsersSelected,
+      },
+    );
+  };
+
+  const handleRevokeSubmit = () => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeBulkSubmit,
+      {
+        selected_users: revokeModal.users.length,
+        all_users_selected: revokeModal.allUsersSelected,
+      },
+    );
+  };
+
+  const handleRemindClose = () => {
+    setRemindModal(modalZeroState);
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.remindBulkCancel,
+      {
+        selected_users: remindModal.users.length,
+        all_users_selected: remindModal.allUsersSelected,
+      },
+    );
+  };
+
+  const handleRevokeCancel = () => {
+    setRevokeModal(modalZeroState);
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.revokeBulkCancel,
+      {
+        selected_users: revokeModal.users.length,
+        all_users_selected: revokeModal.allUsersSelected,
+      },
+    );
   };
 
   return (
@@ -125,8 +189,9 @@ const LicenseManagementTableBulkActions = ({
         isOpen={revokeModal.isOpen}
         usersToRevoke={revokeModal.users}
         subscription={subscription}
-        onClose={() => setRevokeModal(modalZeroState)}
+        onClose={handleRevokeCancel}
         onSuccess={handleRevokeSuccess}
+        onSubmit={handleRevokeSubmit}
         revokeAllUsers={revokeModal.allUsersSelected}
         totalToRevoke={activatedUsers + assignedUsers}
       />
@@ -134,8 +199,9 @@ const LicenseManagementTableBulkActions = ({
         isOpen={remindModal.isOpen}
         usersToRemind={remindModal.users}
         subscription={subscription}
-        onClose={() => setRemindModal(modalZeroState)}
+        onClose={handleRemindClose}
         onSuccess={handleRemindSuccess}
+        onSubmit={handleRemindSubmit}
         remindAllUsers={remindModal.allUsersSelected}
         totalToRemind={assignedUsers}
       />
@@ -150,6 +216,7 @@ LicenseManagementTableBulkActions.defaultProps = {
 LicenseManagementTableBulkActions.propTypes = {
   subscription: PropTypes.shape({
     uuid: PropTypes.string.isRequired,
+    enterpriseCustomerUuid: PropTypes.string.isRequired,
     expirationDate: PropTypes.string.isRequired,
     isRevocationCapEnabled: PropTypes.bool.isRequired,
     revocations: PropTypes.shape({

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -25,7 +25,7 @@ import DownloadCsvButton from '../../buttons/DownloadCsvButton';
 import LicenseManagementTableBulkActions from './LicenseManagementTableBulkActions';
 import LicenseManagementTableActionColumn from './LicenseManagementTableActionColumn';
 import LicenseManagementUserBadge from './LicenseManagementUserBadge';
-import { subscriptionsTableEventNames } from '../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../eventTracking';
 
 const userRecentAction = (user) => {
   switch (user.status) {
@@ -82,7 +82,7 @@ const LicenseManagementTable = () => {
   const sendStatusFilterEvent = (statusFilter) => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.filterStatusChange,
+      SUBSCRIPTION_TABLE_EVENTS.FILTER_STATUS,
       { applied_filters: statusFilter },
     );
   };
@@ -90,15 +90,15 @@ const LicenseManagementTable = () => {
   const sendEmailFilterEvent = (emailFilter) => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
-      subscriptionsTableEventNames.filterEmailChange,
+      SUBSCRIPTION_TABLE_EVENTS.FILTER_EMAIL,
       { email_filter: emailFilter },
     );
   };
 
   const sendPaginationEvent = (oldPage, newPage) => {
     const eventName = newPage - oldPage > 0
-      ? subscriptionsTableEventNames.paginationNext
-      : subscriptionsTableEventNames.paginationPrevious;
+      ? SUBSCRIPTION_TABLE_EVENTS.PAGINATION_NEXT
+      : SUBSCRIPTION_TABLE_EVENTS.PAGINATION_PREVIOUS;
 
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -87,11 +87,10 @@ const LicenseManagementTable = () => {
     );
   };
 
-  const sendEmailFilterEvent = (emailFilter) => {
+  const sendEmailFilterEvent = () => {
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
       SUBSCRIPTION_TABLE_EVENTS.FILTER_EMAIL,
-      { email_filter: emailFilter },
     );
   };
 
@@ -122,7 +121,7 @@ const LicenseManagementTable = () => {
             break;
           }
           case 'emailLabel': {
-            sendEmailFilterEvent(filter.value);
+            sendEmailFilterEvent();
             setSearchQuery(filter.value);
             break;
           }

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -99,6 +99,7 @@ const LicenseManagementTable = () => {
     const eventName = newPage - oldPage > 0
       ? subscriptionsTableEventNames.paginationNext
       : subscriptionsTableEventNames.paginationPrevious;
+
     sendEnterpriseTrackEvent(
       subscription.enterpriseCustomerUuid,
       eventName,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -10,6 +10,7 @@ import {
 } from '@edx/paragon';
 import debounce from 'lodash.debounce';
 import moment from 'moment';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { SubscriptionContext } from '../../SubscriptionData';
 import { SubscriptionDetailContext, defaultStatusFilter } from '../../SubscriptionDetailContextProvider';
@@ -24,6 +25,7 @@ import DownloadCsvButton from '../../buttons/DownloadCsvButton';
 import LicenseManagementTableBulkActions from './LicenseManagementTableBulkActions';
 import LicenseManagementTableActionColumn from './LicenseManagementTableActionColumn';
 import LicenseManagementUserBadge from './LicenseManagementUserBadge';
+import { subscriptionsTableEventNames } from '../../../../eventTracking';
 
 const userRecentAction = (user) => {
   switch (user.status) {
@@ -77,6 +79,33 @@ const LicenseManagementTable = () => {
   // enrollment modal is implemented
   const enrollmentLink = (window.location.href).replace('subscriptions', 'enrollment');
 
+  const sendStatusFilterEvent = (statusFilter) => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.filterStatusChange,
+      { applied_filters: statusFilter },
+    );
+  };
+
+  const sendEmailFilterEvent = (emailFilter) => {
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      subscriptionsTableEventNames.filterEmailChange,
+      { email_filter: emailFilter },
+    );
+  };
+
+  const sendPaginationEvent = (oldPage, newPage) => {
+    const eventName = newPage - oldPage > 0
+      ? subscriptionsTableEventNames.paginationNext
+      : subscriptionsTableEventNames.paginationPrevious;
+    sendEnterpriseTrackEvent(
+      subscription.enterpriseCustomerUuid,
+      eventName,
+      { page: newPage },
+    );
+  };
+
   // Filtering and pagination
   const updateFilters = (filters) => {
     if (filters.length < 1) {
@@ -85,12 +114,17 @@ const LicenseManagementTable = () => {
     } else {
       filters.forEach((filter) => {
         switch (filter.id) {
-          case 'statusBadge':
-            setUserStatusFilter(filter.value.join());
+          case 'statusBadge': {
+            const newStatusFilter = filter.value.join();
+            sendStatusFilterEvent(newStatusFilter);
+            setUserStatusFilter(newStatusFilter);
             break;
-          case 'emailLabel':
+          }
+          case 'emailLabel': {
+            sendEmailFilterEvent(filter.value);
             setSearchQuery(filter.value);
             break;
+          }
           default: break;
         }
       });
@@ -112,6 +146,7 @@ const LicenseManagementTable = () => {
       // pages index from 1 in backend, DataTable component index from 0
       if (args.pageIndex !== currentPage - 1) {
         debouncedSetCurrentPage(args.pageIndex + 1);
+        sendPaginationEvent(currentPage - 1, args.pageIndex);
       }
       debouncedUpdateFilters(args.filters);
     },

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
-import * as enterpriseUtils from '@edx/frontend-enterprise-utils';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import LicenseManagementTableActionColumn from '../LicenseManagementTableActionColumn';
 import {
@@ -118,14 +118,14 @@ describe('<LicenseManagementTableActionColumn />', () => {
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
     // Event is sent when open
-    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
       subscriptionsTableEventNames.revokeRowClick,
     );
     // Close dialog
     testDialogClosed();
     // Event is sent when cancel
-    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
       subscriptionsTableEventNames.revokeRowCancel,
     );
@@ -141,14 +141,14 @@ describe('<LicenseManagementTableActionColumn />', () => {
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
     // Event is sent when open
-    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
       subscriptionsTableEventNames.remindRowClick,
     );
     // Close dialog
     testDialogClosed();
     // Event is sent when cancel
-    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
       subscriptionsTableEventNames.remindRowCancel,
     );

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
@@ -17,7 +17,7 @@ import {
   ACTIVATED,
   REVOKED,
 } from '../../../data/constants';
-import { subscriptionsTableEventNames } from '../../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../../eventTracking';
 import {
   TEST_ENTERPRISE_CUSTOMER_UUID,
   TEST_SUBSCRIPTION_PLAN_UUID,
@@ -120,14 +120,14 @@ describe('<LicenseManagementTableActionColumn />', () => {
     // Event is sent when open
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.revokeRowClick,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_ROW_CLICK,
     );
     // Close dialog
     testDialogClosed();
     // Event is sent when cancel
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.revokeRowCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_ROW_CANCEL,
     );
   });
 
@@ -143,14 +143,14 @@ describe('<LicenseManagementTableActionColumn />', () => {
     // Event is sent when open
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.remindRowClick,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_ROW_CLICK,
     );
     // Close dialog
     testDialogClosed();
     // Event is sent when cancel
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.remindRowCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_ROW_CANCEL,
     );
   });
 });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
+import * as enterpriseUtils from '@edx/frontend-enterprise-utils';
 
 import LicenseManagementTableActionColumn from '../LicenseManagementTableActionColumn';
 import {
@@ -16,6 +17,15 @@ import {
   ACTIVATED,
   REVOKED,
 } from '../../../data/constants';
+import { subscriptionsTableEventNames } from '../../../../../eventTracking';
+import {
+  TEST_ENTERPRISE_CUSTOMER_UUID,
+  TEST_SUBSCRIPTION_PLAN_UUID,
+} from '../../../tests/TestUtilities';
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
 
 const mockStore = configureMockStore();
 const store = mockStore({
@@ -35,7 +45,8 @@ const basicProps = {
   onRemindSuccess: () => {},
   onRevokeSuccess: () => {},
   subscription: {
-    uuid: '1',
+    uuid: TEST_SUBSCRIPTION_PLAN_UUID,
+    enterpriseCustomerUuid: TEST_ENTERPRISE_CUSTOMER_UUID,
     expirationDate: moment().add(1, 'days').format(),
     isRevocationCapEnabled: false,
     revocations: {
@@ -54,6 +65,7 @@ const LicenseManagementTableActionColumnWithContext = (props) => (
 describe('<LicenseManagementTableActionColumn />', () => {
   afterEach(() => {
     cleanup();
+    jest.clearAllMocks();
   });
   const testDialogClosed = () => {
     const cancelButton = screen.getByText('Cancel');
@@ -105,12 +117,18 @@ describe('<LicenseManagementTableActionColumn />', () => {
       await userEvent.click(revokeButton);
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
+    // Event is sent when open
+    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.revokeRowClick,
+    );
     // Close dialog
-    const cancelButton = screen.getByText('Cancel');
-    act(() => {
-      userEvent.click(cancelButton);
-    });
-    expect(screen.queryByRole('dialog')).toBeFalsy();
+    testDialogClosed();
+    // Event is sent when cancel
+    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.revokeRowCancel,
+    );
   });
 
   it('opens and closes remind modal', async () => {
@@ -122,7 +140,17 @@ describe('<LicenseManagementTableActionColumn />', () => {
       await userEvent.click(remindButton);
     });
     expect(screen.getByRole('dialog')).toBeTruthy();
+    // Event is sent when open
+    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.remindRowClick,
+    );
     // Close dialog
     testDialogClosed();
+    // Event is sent when cancel
+    expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.remindRowCancel,
+    );
   });
 });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
@@ -9,13 +9,23 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
+import { subscriptionsTableEventNames } from '../../../../../eventTracking';
 import LicenseManagementTableBulkActions from '../LicenseManagementTableBulkActions';
 import {
   ASSIGNED,
   ACTIVATED,
   REVOKED,
 } from '../../../data/constants';
+import {
+  TEST_ENTERPRISE_CUSTOMER_UUID,
+  TEST_SUBSCRIPTION_PLAN_UUID,
+} from '../../../tests/TestUtilities';
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
 
 const mockStore = configureMockStore();
 const store = mockStore({
@@ -32,7 +42,8 @@ const basicProps = {
   activatedUsers: 0,
   assignedUsers: 0,
   subscription: {
-    uuid: '1',
+    uuid: TEST_SUBSCRIPTION_PLAN_UUID,
+    enterpriseCustomerUuid: TEST_ENTERPRISE_CUSTOMER_UUID,
     expirationDate: moment().add(1, 'days').format(),
     isRevocationCapEnabled: false,
     revocations: {
@@ -159,9 +170,22 @@ describe('<LicenseManagementTableBulkActions />', () => {
     await act(async () => {
       await userEvent.click(remindButton);
     });
+    // Event is sent when open
+    const eventPayload = { selected_users: 1, all_users_selected: false };
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.remindBulkClick,
+      eventPayload,
+    );
     expect(screen.getByRole('dialog')).toBeTruthy();
     // Close dialog
     testDialogClosed();
+    // Event is sent when cancel
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.remindBulkCancel,
+      eventPayload,
+    );
   });
 
   it('opens and closes revoke modal', async () => {
@@ -177,8 +201,21 @@ describe('<LicenseManagementTableBulkActions />', () => {
     await act(async () => {
       userEvent.click(revokeButton);
     });
+    // Event is sent when open
+    const eventPayload = { selected_users: 1, all_users_selected: false };
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.revokeBulkClick,
+      eventPayload,
+    );
     expect(screen.getByRole('dialog')).toBeTruthy();
     // Close dialog
     testDialogClosed();
+    // Event is sent when cancel
+    expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_CUSTOMER_UUID,
+      subscriptionsTableEventNames.revokeBulkCancel,
+      eventPayload,
+    );
   });
 });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableBulkActions.test.jsx
@@ -11,7 +11,7 @@ import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
-import { subscriptionsTableEventNames } from '../../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../../eventTracking';
 import LicenseManagementTableBulkActions from '../LicenseManagementTableBulkActions';
 import {
   ASSIGNED,
@@ -174,7 +174,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     const eventPayload = { selected_users: 1, all_users_selected: false };
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.remindBulkClick,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_BULK_CLICK,
       eventPayload,
     );
     expect(screen.getByRole('dialog')).toBeTruthy();
@@ -183,7 +183,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     // Event is sent when cancel
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.remindBulkCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REMIND_BULK_CANCEL,
       eventPayload,
     );
   });
@@ -205,7 +205,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     const eventPayload = { selected_users: 1, all_users_selected: false };
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.revokeBulkClick,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_CLICK,
       eventPayload,
     );
     expect(screen.getByRole('dialog')).toBeTruthy();
@@ -214,7 +214,7 @@ describe('<LicenseManagementTableBulkActions />', () => {
     // Event is sent when cancel
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
-      subscriptionsTableEventNames.revokeBulkCancel,
+      SUBSCRIPTION_TABLE_EVENTS.REVOKE_BULK_CANCEL,
       eventPayload,
     );
   });

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
@@ -20,7 +20,7 @@ import {
 } from '../../../tests/TestUtilities';
 import LicenseManagementTable from '../index';
 import * as hooks from '../../../data/hooks';
-import { subscriptionsTableEventNames } from '../../../../../eventTracking';
+import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../../eventTracking';
 import { DEBOUNCE_TIME_MILLIS } from '../../../../../algoliaUtils';
 import { PAGE_SIZE } from '../../../data/constants';
 
@@ -267,7 +267,7 @@ describe('<LicenseManagementTable />', () => {
 
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
-        subscriptionsTableEventNames.filterStatusChange,
+        SUBSCRIPTION_TABLE_EVENTS.FILTER_STATUS,
         { applied_filters: 'activated' },
       );
     });
@@ -285,7 +285,7 @@ describe('<LicenseManagementTable />', () => {
 
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
-        subscriptionsTableEventNames.filterEmailChange,
+        SUBSCRIPTION_TABLE_EVENTS.FILTER_EMAIL,
         { email_filter: 'foo' },
       );
     });
@@ -302,7 +302,7 @@ describe('<LicenseManagementTable />', () => {
       });
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
-        subscriptionsTableEventNames.paginationNext,
+        SUBSCRIPTION_TABLE_EVENTS.PAGINATION_NEXT,
         { page: 1 },
       );
       const prevPageButton = screen.getByText('Previous');
@@ -313,7 +313,7 @@ describe('<LicenseManagementTable />', () => {
       });
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
-        subscriptionsTableEventNames.paginationPrevious,
+        SUBSCRIPTION_TABLE_EVENTS.PAGINATION_PREVIOUS,
         { page: 0 },
       );
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledTimes(2);

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
@@ -286,7 +286,6 @@ describe('<LicenseManagementTable />', () => {
       expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
         SUBSCRIPTION_TABLE_EVENTS.FILTER_EMAIL,
-        { email_filter: 'foo' },
       );
     });
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
@@ -3,22 +3,52 @@ import {
   screen,
   render,
   cleanup,
+  act,
+  fireEvent,
 } from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import moment from 'moment';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { ToastsContext } from '../../../../Toasts';
 import SubscriptionDetailContextProvider from '../../../SubscriptionDetailContextProvider';
 import SubscriptionData from '../../../SubscriptionData';
-
+import {
+  TEST_ENTERPRISE_CUSTOMER_UUID,
+} from '../../../tests/TestUtilities';
 import LicenseManagementTable from '../index';
 import * as hooks from '../../../data/hooks';
+import { subscriptionsTableEventNames } from '../../../../../eventTracking';
+import { DEBOUNCE_TIME_MILLIS } from '../../../../../algoliaUtils';
+import { PAGE_SIZE } from '../../../data/constants';
 
 const mockStore = configureMockStore();
 const store = mockStore({
   portalConfiguration: {
-    enterpriseId: 'test-enterprise-id',
+    enterpriseId: TEST_ENTERPRISE_CUSTOMER_UUID,
   },
+});
+
+jest.useFakeTimers('modern');
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
+
+const generateSubscriptionUser = (
+  uuid = 'test-uuid',
+  userEmail = 'edx@example.com',
+  status = 'activated',
+) => ({
+  activationDate: moment(),
+  activationKey: 'test-activation-key',
+  lastRemindDate: moment(),
+  revokedDate: null,
+  status,
+  userEmail,
+  uuid,
 });
 
 const nonExpiredSubscriptionPlan = (
@@ -31,8 +61,7 @@ const nonExpiredSubscriptionPlan = (
     uuid: 'bar',
     startDate: startDate.format(),
     expirationDate: startDate.add(daysUntilExpiration, 'days').format(),
-    enterpriseCustomerUuid: 'foo',
-    enterpriseCatalogUuid: 'foo',
+    enterpriseCustomerUuid: TEST_ENTERPRISE_CUSTOMER_UUID,
     isActive: true,
     licenses: {
       total: 10,
@@ -92,7 +121,7 @@ const generateUseSubscriptionUsers = (subscriptionUsers) => ({
   count: 0,
   next: null,
   previous: null,
-  numPages: 1,
+  numPages: 2,
   results: subscriptionUsers,
 });
 
@@ -202,6 +231,92 @@ describe('<LicenseManagementTable />', () => {
         }));
         expect(screen.getByTitle('Toggle Row Selected'));
       });
+    });
+  });
+
+  describe('sends events', () => {
+    const subscriptionPlan = nonExpiredSubscriptionPlan();
+    const users = [];
+    for (let n = 0; n < PAGE_SIZE + 10; n++) {
+      users.push(generateSubscriptionUser(
+        `uuid-${n}`, `${n}@edx.org`, 'assigned',
+      ));
+    }
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+    beforeEach(() => {
+      mockHooks({
+        subscriptionPlan,
+        subscriptionUsers: users,
+      });
+    });
+    it('when clicking status filters', async () => {
+      render(tableWithContext({
+        subscriptionPlan,
+      }));
+
+      // click status checkbox
+      const activeCheckBox = screen.getByText('Active');
+      await act(async () => {
+        userEvent.click(activeCheckBox);
+        // filter debounce
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MILLIS);
+      });
+
+      expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+        TEST_ENTERPRISE_CUSTOMER_UUID,
+        subscriptionsTableEventNames.filterStatusChange,
+        { applied_filters: 'activated' },
+      );
+    });
+    it('when typing in to email filter', async () => {
+      render(tableWithContext({
+        subscriptionPlan,
+      }));
+      const emailInput = screen.getByPlaceholderText('Search Email address');
+      // type in 'foo' to email input
+      fireEvent.change(emailInput, { target: { value: 'foo' } });
+
+      act(() => {
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MILLIS);
+      });
+
+      expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+        TEST_ENTERPRISE_CUSTOMER_UUID,
+        subscriptionsTableEventNames.filterEmailChange,
+        { email_filter: 'foo' },
+      );
+    });
+
+    it('when changing to the page', async () => {
+      render(tableWithContext({
+        subscriptionPlan,
+      }));
+      const nextPageButton = screen.getByText('Next');
+      await act(async () => {
+        userEvent.click(nextPageButton);
+        // filter debounce
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MILLIS);
+      });
+      expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+        TEST_ENTERPRISE_CUSTOMER_UUID,
+        subscriptionsTableEventNames.paginationNext,
+        { page: 1 },
+      );
+      const prevPageButton = screen.getByText('Previous');
+      await act(async () => {
+        userEvent.click(prevPageButton);
+        // filter debounce
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MILLIS);
+      });
+      expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
+        TEST_ENTERPRISE_CUSTOMER_UUID,
+        subscriptionsTableEventNames.paginationPrevious,
+        { page: 0 },
+      );
+      expect(sendEnterpriseTrackEvent).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -18,6 +18,12 @@ const PROJECT_NAME = 'edx.ui.admin_portal';
  */
 const SUBSCRIPTION_TABLE = `${PROJECT_NAME}.subscriptions.table`;
 export const subscriptionsTableEventNames = {
+  // Pagination 
+  paginationNext: `${SUBSCRIPTION_TABLE}.pagination.next.click`,
+  paginationPrevious: `${SUBSCRIPTION_TABLE}.pagination.previous.click`,
+  // Filter Actions
+  filterStatusChange: `${SUBSCRIPTION_TABLE}.filter.status.change`,
+  filterEmailChange: `${SUBSCRIPTION_TABLE}.filter.email.change`,
   // Row Actions
   remindRowClick: `${SUBSCRIPTION_TABLE}.remind.row.click`,
   remindRowSubmit: `${SUBSCRIPTION_TABLE}.remind.row.submit`,

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -4,38 +4,48 @@
  * Event names should fallow the convention of:
  * <project name>.<product name>.<location>.<action>
  *
- * @example edx.ui.admin_portal. (project) subscriptions. (product) table. (location) click (action)
- * edx.ui.admin_portal.subscriptions.table.click
+ * @example edx.ui.admin_portal. (project) subscriptions. (product) table. (location) clicked (action)
+ * edx.ui.admin_portal.subscriptions.table.clicked
  */
 
 /**
  * @constant PROJECT_NAME leading project identifier for event names
  */
-export const PROJECT_NAME = 'edx.ui.admin_portal';
+const PROJECT_NAME = 'edx.ui.enterprise.admin_portal';
 
-/**
- * Subscription detail table events
- */
-const SUBSCRIPTION_TABLE = `${PROJECT_NAME}.subscriptions.table`;
-export const subscriptionsTableEventNames = {
+const SUBSCRIPTION_PREFIX = `${PROJECT_NAME}.subscriptions`;
+
+const SUBSCRIPTION_TABLE_PREFIX = `${SUBSCRIPTION_PREFIX}.table`;
+
+export const SUBSCRIPTION_TABLE_EVENTS = {
   // Pagination
-  paginationNext: `${SUBSCRIPTION_TABLE}.pagination.next.click`,
-  paginationPrevious: `${SUBSCRIPTION_TABLE}.pagination.previous.click`,
+  PAGINATION_NEXT: `${SUBSCRIPTION_TABLE_PREFIX}.pagination.next.clicked`,
+  PAGINATION_PREVIOUS: `${SUBSCRIPTION_TABLE_PREFIX}.pagination.previous.clicked`,
   // Filter Actions
-  filterStatusChange: `${SUBSCRIPTION_TABLE}.filter.status.change`,
-  filterEmailChange: `${SUBSCRIPTION_TABLE}.filter.email.change`,
+  FILTER_STATUS: `${SUBSCRIPTION_TABLE_PREFIX}.filter.status.changed`,
+  FILTER_EMAIL: `${SUBSCRIPTION_TABLE_PREFIX}.filter.email.changed`,
   // Row Actions
-  remindRowClick: `${SUBSCRIPTION_TABLE}.remind.row.click`,
-  remindRowSubmit: `${SUBSCRIPTION_TABLE}.remind.row.submit`,
-  remindRowCancel: `${SUBSCRIPTION_TABLE}.remind.row.cancel`,
-  revokeRowClick: `${SUBSCRIPTION_TABLE}.revoke.row.click`,
-  revokeRowSubmit: `${SUBSCRIPTION_TABLE}.revoke.row.submit`,
-  revokeRowCancel: `${SUBSCRIPTION_TABLE}.revoke.row.cancel`,
+  REMIND_ROW_CLICK: `${SUBSCRIPTION_TABLE_PREFIX}.remind.row.clicked`,
+  REMIND_ROW_SUBMIT: `${SUBSCRIPTION_TABLE_PREFIX}.remind.row.submitted`,
+  REMIND_ROW_CANCEL: `${SUBSCRIPTION_TABLE_PREFIX}.remind.row.canceled`,
+  REVOKE_ROW_CLICK: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.row.clicked`,
+  REVOKE_ROW_SUBMIT: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.row.submitted`,
+  REVOKE_ROW_CANCEL: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.row.canceled`,
   // Bulk Actions
-  remindBulkClick: `${SUBSCRIPTION_TABLE}.remind.bulk.click`,
-  remindBulkSubmit: `${SUBSCRIPTION_TABLE}.remind.bulk.submit`,
-  remindBulkCancel: `${SUBSCRIPTION_TABLE}.remind.bulk.cancel`,
-  revokeBulkClick: `${SUBSCRIPTION_TABLE}.revoke.bulk.click`,
-  revokeBulkSubmit: `${SUBSCRIPTION_TABLE}.revoke.bulk.submit`,
-  revokeBulkCancel: `${SUBSCRIPTION_TABLE}.revoke.bulk.cancel`,
+  REMIND_BULK_CLICK: `${SUBSCRIPTION_TABLE_PREFIX}.remind.bulk.clicked`,
+  REMIND_BULK_SUBMIT: `${SUBSCRIPTION_TABLE_PREFIX}.remind.bulk.submitted`,
+  REMIND_BULK_CANCEL: `${SUBSCRIPTION_TABLE_PREFIX}.remind.bulk.canceled`,
+  REVOKE_BULK_CLICK: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.bulk.clicked`,
+  REVOKE_BULK_SUBMIT: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.bulk.submitted`,
+  REVOKE_BULK_CANCEL: `${SUBSCRIPTION_TABLE_PREFIX}.revoke.bulk.canceled`,
 };
+
+export const SUBSCRIPTION_EVENTS = {
+  TABLE: SUBSCRIPTION_TABLE_EVENTS,
+};
+
+const EVENT_NAMES = {
+  SUBSCRIPTIONS: SUBSCRIPTION_EVENTS,
+};
+
+export default EVENT_NAMES;

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -11,7 +11,7 @@
 /**
  * @constant PROJECT_NAME leading project identifier for event names
  */
-const PROJECT_NAME = 'edx.ui.admin_portal';
+export const PROJECT_NAME = 'edx.ui.admin_portal';
 
 /**
  * Subscription detail table events
@@ -38,7 +38,4 @@ export const subscriptionsTableEventNames = {
   revokeBulkClick: `${SUBSCRIPTION_TABLE}.revoke.bulk.click`,
   revokeBulkSubmit: `${SUBSCRIPTION_TABLE}.revoke.bulk.submit`,
   revokeBulkCancel: `${SUBSCRIPTION_TABLE}.revoke.bulk.cancel`,
-};
-
-export const subscriptionExpiration = {
 };

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -1,0 +1,30 @@
+/**
+ * @file Documents event tracking name space
+ */
+
+export const PROJECT_NAME = 'edx.ui.admin_portal';
+
+/**
+ * Subscription detail table events
+ */
+export const subscriptionsTableEventNames = {
+  base: 'subscriptions.table',
+  get remindRowClick() {
+    return `${PROJECT_NAME}.${this.base}.remind.row.click`;
+  },
+  get remindRowSubmit() {
+    return `${PROJECT_NAME}.${this.base}.remind.row.submit`;
+  },
+  get remindRowCancel() {
+    return `${PROJECT_NAME}.${this.base}.remind.row.cancel`;
+  },
+  get revokeRowClick() {
+    return `${PROJECT_NAME}.${this.base}.revoke.row.click`;
+  },
+  get revokeRowSubmit() {
+    return `${PROJECT_NAME}.${this.base}.revoke.row.submit`;
+  },
+  get revokeRowCancel() {
+    return `${PROJECT_NAME}.${this.base}.revoke.row.cancel`;
+  },
+};

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -18,7 +18,7 @@ const PROJECT_NAME = 'edx.ui.admin_portal';
  */
 const SUBSCRIPTION_TABLE = `${PROJECT_NAME}.subscriptions.table`;
 export const subscriptionsTableEventNames = {
-  // Pagination 
+  // Pagination
   paginationNext: `${SUBSCRIPTION_TABLE}.pagination.next.click`,
   paginationPrevious: `${SUBSCRIPTION_TABLE}.pagination.previous.click`,
   // Filter Actions

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -1,30 +1,38 @@
 /**
  * @file Documents event tracking name space
+ *
+ * Event names should fallow the convention of:
+ * <project name>.<product name>.<location>.<action>
+ *
+ * @example edx.ui.admin_portal. (project) subscriptions. (product) table. (location) click (action)
+ * edx.ui.admin_portal.subscriptions.table.click
  */
 
-export const PROJECT_NAME = 'edx.ui.admin_portal';
+/**
+ * @constant PROJECT_NAME leading project identifier for event names
+ */
+const PROJECT_NAME = 'edx.ui.admin_portal';
 
 /**
  * Subscription detail table events
  */
+const SUBSCRIPTION_TABLE = `${PROJECT_NAME}.subscriptions.table`;
 export const subscriptionsTableEventNames = {
-  base: 'subscriptions.table',
-  get remindRowClick() {
-    return `${PROJECT_NAME}.${this.base}.remind.row.click`;
-  },
-  get remindRowSubmit() {
-    return `${PROJECT_NAME}.${this.base}.remind.row.submit`;
-  },
-  get remindRowCancel() {
-    return `${PROJECT_NAME}.${this.base}.remind.row.cancel`;
-  },
-  get revokeRowClick() {
-    return `${PROJECT_NAME}.${this.base}.revoke.row.click`;
-  },
-  get revokeRowSubmit() {
-    return `${PROJECT_NAME}.${this.base}.revoke.row.submit`;
-  },
-  get revokeRowCancel() {
-    return `${PROJECT_NAME}.${this.base}.revoke.row.cancel`;
-  },
+  // Row Actions
+  remindRowClick: `${SUBSCRIPTION_TABLE}.remind.row.click`,
+  remindRowSubmit: `${SUBSCRIPTION_TABLE}.remind.row.submit`,
+  remindRowCancel: `${SUBSCRIPTION_TABLE}.remind.row.cancel`,
+  revokeRowClick: `${SUBSCRIPTION_TABLE}.revoke.row.click`,
+  revokeRowSubmit: `${SUBSCRIPTION_TABLE}.revoke.row.submit`,
+  revokeRowCancel: `${SUBSCRIPTION_TABLE}.revoke.row.cancel`,
+  // Bulk Actions
+  remindBulkClick: `${SUBSCRIPTION_TABLE}.remind.bulk.click`,
+  remindBulkSubmit: `${SUBSCRIPTION_TABLE}.remind.bulk.submit`,
+  remindBulkCancel: `${SUBSCRIPTION_TABLE}.remind.bulk.cancel`,
+  revokeBulkClick: `${SUBSCRIPTION_TABLE}.revoke.bulk.click`,
+  revokeBulkSubmit: `${SUBSCRIPTION_TABLE}.revoke.bulk.submit`,
+  revokeBulkCancel: `${SUBSCRIPTION_TABLE}.revoke.bulk.cancel`,
+};
+
+export const subscriptionExpiration = {
 };


### PR DESCRIPTION
# Context

[Close ENT-5062](https://openedx.atlassian.net/browse/ENT-5062) 

This PR includes no visual changes.

Adds segment events to the subscription management table and put event names all in one place.



## Events:

### Bulk Actions:
All bulk action events have this payload: 
`{ selected_users: <num>, all_users_selected: <bool> }`

Clicking on bulk remind or revoke buttons after selecting users sends:
* `edx.ui.admin_portal.subscriptions.table.remind.bulk.click`
OR
* `edx.ui.admin_portal.subscriptions.table.revoke.bulk.click`

![Screen Shot 2021-11-09 at 8 58 19 AM](https://user-images.githubusercontent.com/6687387/140937672-f265eb16-3d24-4d14-b2d7-d677f958a967.png)


Clicking bulk actions brings up the corresponding action modal with two buttons, cancel and submit. These buttons map to the fallowing event names:

* `edx.ui.admin_portal.subscriptions.table.remind.bulk.submit`
* `edx.ui.admin_portal.subscriptions.table.remind.bulk.cancel`
OR
* `edx.ui.admin_portal.subscriptions.table.revoke.bulk.submit`
* `edx.ui.admin_portal.subscriptions.table.revoke.bulk.cancel`

![Screen Shot 2021-11-09 at 8 58 51 AM](https://user-images.githubusercontent.com/6687387/140946774-119789e7-a194-4da7-8c5f-2555ba173928.png)


### In Row Actions:

A similar pattern is fallowed with row actions where clicking on them is mapped to:

* `edx.ui.admin_portal.subscriptions.table.remind.row.click`
OR
* `edx.ui.admin_portal.subscriptions.table.revoke.row.click`

![Screen Shot 2021-11-09 at 8 47 48 AM](https://user-images.githubusercontent.com/6687387/140948126-d02797cc-422a-4e36-885e-fd043cbb9180.png)

Modal actions are also similar:
* `edx.ui.admin_portal.subscriptions.table.remind.row.submit`
* `edx.ui.admin_portal.subscriptions.table.remind.row.cancel`
OR
* `edx.ui.admin_portal.subscriptions.table.revoke.row.submit`
* `edx.ui.admin_portal.subscriptions.table.revoke.row.cancel`

### Filtering
With filtering, we track changes to the status filter and email filter.

* `edx.ui.admin_portal.subscriptions.table.filter.status.change`
  * with payload { applied_filters: <string> }
* `edx.ui.admin_portal.subscriptions.table.filter.email.change
  * with payload { email_filter: <string> }

### Pagination 
We also track clicking the previous and next buttons on the table.
* `edx.ui.admin_portal.subscriptions.table.pagination.previous.click`
* `edx.ui.admin_portal.subscriptions.table.pagination.next.click`

With the a payload of `{ page: <number> }` where page is the new page, indexed from 0.


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)