### PR TITLE
feat: OAuth Auth link for Blackboard Self-Service

### DIFF
--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
@@ -110,16 +110,6 @@ class BlackboardIntegrationConfigForm extends React.Component {
         </div>
       );
     }
-    let authLinkDisplay;
-    if (config && config.oauthAuthorizationUrl) {
-      authLinkDisplay = (
-        <div className="form-group align-items-left">
-          <Hyperlink destination={config ? config.oauthAuthorizationUrl : null} target="_blank">
-            Authorize
-          </Hyperlink>
-        </div>
-      );
-    }
 
     return (
       <form
@@ -224,13 +214,16 @@ class BlackboardIntegrationConfigForm extends React.Component {
 
         <div className="row">
           <div className="col col-4">
-            <ValidationFormGroup
-              for="oauthAuthorizationUrl"
-              helpText="OAuth Authorization Link. Will be available once Base URL and Client ID are supplied."
-            >
-              <label htmlFor="oauthAuthorizationUrl">OAuth Authoriation URL</label>
-              {authLinkDisplay}
-            </ValidationFormGroup>
+            {config?.oauthAuthorizationUrl && (
+            <div className="form-group align-items-left">
+              <Hyperlink destination={config ? config.oauthAuthorizationUrl : null} target="_blank">
+                Authorize
+              </Hyperlink>
+              <p className="small">
+                OAuth Authorization Link. Will be available once Base URL and Client ID are supplied.
+              </p>
+            </div>
+            )}
           </div>
         </div>
 

--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import {
-  ValidationFormGroup, Input, StatefulButton, Icon, Hyperlink,
+  ValidationFormGroup,
+  Input,
+  StatefulButton,
+  Icon,
+  Hyperlink,
 } from '@edx/paragon';
 import { snakeCaseFormData } from '../../utils';
 import LmsApiService from '../../data/services/LmsApiService';

--- a/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
+++ b/src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import {
-  ValidationFormGroup, Input, StatefulButton, Icon,
+  ValidationFormGroup, Input, StatefulButton, Icon, Hyperlink,
 } from '@edx/paragon';
 import { snakeCaseFormData } from '../../utils';
 import LmsApiService from '../../data/services/LmsApiService';
@@ -110,6 +110,16 @@ class BlackboardIntegrationConfigForm extends React.Component {
         </div>
       );
     }
+    let authLinkDisplay;
+    if (config && config.oauthAuthorizationUrl) {
+      authLinkDisplay = (
+        <div className="form-group align-items-left">
+          <Hyperlink destination={config ? config.oauthAuthorizationUrl : null} target="_blank">
+            Authorize
+          </Hyperlink>
+        </div>
+      );
+    }
 
     return (
       <form
@@ -213,6 +223,18 @@ class BlackboardIntegrationConfigForm extends React.Component {
         </div>
 
         <div className="row">
+          <div className="col col-4">
+            <ValidationFormGroup
+              for="oauthAuthorizationUrl"
+              helpText="OAuth Authorization Link. Will be available once Base URL and Client ID are supplied."
+            >
+              <label htmlFor="oauthAuthorizationUrl">OAuth Authoriation URL</label>
+              {authLinkDisplay}
+            </ValidationFormGroup>
+          </div>
+        </div>
+
+        <div className="row">
           <div className="col col-2">
             <StatefulButton
               state={submitState}
@@ -258,6 +280,7 @@ BlackboardIntegrationConfigForm.propTypes = {
     refreshToken: PropTypes.string,
     clientId: PropTypes.string,
     clientSecret: PropTypes.string,
+    oauthAuthorizationUrl: PropTypes.string,
   }),
   enterpriseId: PropTypes.string,
 };


### PR DESCRIPTION
When available, display an OAuth Client Authorization link in the Blackboard self-service screen of the admin portal. 

Relies on https://github.com/edx/edx-enterprise/pull/1425

[ENT-4389](https://openedx.atlassian.net/browse/ENT-4389)

![Screen Shot 2021-12-10 at 1 35 04 PM](https://user-images.githubusercontent.com/31442/145624437-35a9443b-d5e6-4d42-b306-a6652dae92a7.png)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
